### PR TITLE
使用非明文方式存储密码

### DIFF
--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -13,7 +13,6 @@
 import re
 import json
 import requests
-import hashlib
 from bs4 import BeautifulSoup
 import logger
 
@@ -75,7 +74,7 @@ class NetEase:
         action = 'http://music.163.com/api/login/'
         data = {
             'username': username,
-            'password': hashlib.md5(password).hexdigest(),
+            'password': password,
             'rememberLogin': 'true'
         }
         try:
@@ -88,7 +87,7 @@ class NetEase:
         action = 'http://music.163.com/api/login/cellphone'
         data = {
             'phone': username,
-            'password': hashlib.md5(password).hexdigest(),
+            'password': password,
             'rememberLogin': 'true'
         }
         try:

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -12,7 +12,7 @@
 
 import curses
 from api import NetEase
-
+import hashlib
 
 class Ui:
     def __init__(self):
@@ -219,7 +219,7 @@ class Ui:
     def build_login(self):
         self.build_login_bar()
         local_account = self.get_account()
-        local_password = self.get_password()
+        local_password = hashlib.md5(self.get_password()).hexdigest()
         login_info = self.netease.login(local_account, local_password)
         account = [local_account,local_password]
         if login_info['code'] != 200:


### PR DESCRIPTION
将硬盘存储的密码改为MD5哈希之后的密码形式.

在硬盘上明文存储密码不是一个好主意,应当储存哈希后的密码值

__注意此patch将导致已登陆用户需要重新登陆__