### PR TITLE
fixed the exception caused by trying to enter next level while datalist is empty

### DIFF
--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -417,6 +417,10 @@ class NetEase:
         action = 'http://music.163.com/api/song/detail?ids=[' + (',').join(tmpids) + ']'
         try:
             data = self.httpRequest('GET', action)
+
+            # the order of data['songs'] is no longer the same as tmpids, so just make the order back
+            data["songs"].sort(key=lambda song: tmpids.index(str(song["id"])))
+
             return data['songs']
         except:
             return []

--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -275,7 +275,7 @@ class Menu:
 
             # 前进
             elif key == ord('l') or key == 10:
-                if self.datatype == 'songs' or self.datatype == 'djchannels' or self.datatype == 'help':
+                if self.datatype == 'songs' or self.datatype == 'djchannels' or self.datatype == 'help' or len(self.datalist) <= 0:
                     continue
                 self.START = time.time()
                 self.ui.build_loading()


### PR DESCRIPTION
If I trying to enter next level of menu while datalist is empty, it caused an exception. For example, in the search menu and choose any of them except "歌曲", for example, I choose "网易精选集"![search](http://7xo6r2.com1.z0.glb.clouddn.com/15-11-9/8469521.jpg)
and then, i just press enter, ![nothing](http://7xo6r2.com1.z0.glb.clouddn.com/15-11-9/8982652.jpg) nothing found, but as a result, the datatype became "top_playlists" and datalist became empty, base on the code
```python
if idx == 0:
    # 搜索结果可以用top_playlists处理
    self.datatype = 'top_playlists'
    self.datalist = ui.build_search('search_playlist')
    self.title = '精选歌单搜索列表'
```
if I press enter in this ui, it will cause an exception when try to access `datalist[0]['playlist_id']`
![exception](http://7xo6r2.com1.z0.glb.clouddn.com/15-11-9/87485279.jpg)
because code is as following, 
```python
 elif datatype == 'top_playlists':
    log.debug(datalist)
    playlist_id = datalist[idx]['playlist_id']
    songs = netease.playlist_detail(playlist_id)
    self.datatype = 'songs'
    self.datalist = netease.dig_info(songs, 'songs')
    self.title += ' > ' + datalist[idx]['playlists_name']
```
so I think it is necessary to make sure datalist is not empty before call dispatch_enter(idx)
```python
 elif key == ord('l') or key == 10:
    if self.datatype == 'songs' or self.datatype == 'djchannels' or self.datatype == 'help' or len(self.datalist) <= 0:
        continue
    self.START = time.time()
    self.ui.build_loading()
    self.dispatch_enter(idx)
    self.index = 0
    self.offset = 0
```
