### PR TITLE
keep track of playing song and fixed the notification bug

### DIFF
--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -97,6 +97,7 @@ class Menu:
         self.storage.load()
         self.collection = self.storage.database['collections'][0]
         self.player = Player()
+        self.player.song_changed_callback = self.song_changed_callback
         self.cache = Cache()
         self.ui = Ui()
         self.netease = NetEase()
@@ -392,26 +393,8 @@ class Menu:
 
             # 加载当前播放列表
             elif key == ord('p'):
-                if len(self.storage.database['player_info']['player_list']) == 0:
-                    continue
-                if not self.at_playing_list:
-                    self.stack.append([self.datatype, self.title, self.datalist, self.offset, self.index])
-                    self.at_playing_list = True
-                self.datatype = self.storage.database['player_info']['player_list_type']
-                self.title = self.storage.database['player_info']['player_list_title']
-                self.datalist = []
-                for i in self.storage.database['player_info']['player_list']:
-                    self.datalist.append(self.storage.database['songs'][i])
-                self.index = self.storage.database['player_info']['idx']
-                self.offset = self.storage.database['player_info']['idx'] / self.step * self.step
-                if self.resume_play:
-                    if self.datatype == "fmsongs":
-                        self.player.end_callback = self.fm_callback
-                    else:
-                        self.player.end_callback = None
-                    self.storage.database['player_info']['idx'] = -1
-                    self.player.play_and_pause(self.index)
-                    self.resume_play = False
+                self.show_playing_list()
+
 
             # 播放模式切换
             elif key == ord('P'):
@@ -601,6 +584,33 @@ class Menu:
                 self.datatype = 'albums'
                 self.datalist = ui.build_search('albums')
                 self.title = '专辑搜索列表'
+
+
+    def show_playing_list(self):
+        if len(self.storage.database['player_info']['player_list']) == 0:
+            return
+        if not self.at_playing_list:
+            self.stack.append([self.datatype, self.title, self.datalist, self.offset, self.index])
+            self.at_playing_list = True
+        self.datatype = self.storage.database['player_info']['player_list_type']
+        self.title = self.storage.database['player_info']['player_list_title']
+        self.datalist = []
+        for i in self.storage.database['player_info']['player_list']:
+            self.datalist.append(self.storage.database['songs'][i])
+        self.index = self.storage.database['player_info']['idx']
+        self.offset = self.storage.database['player_info']['idx'] / self.step * self.step
+        if self.resume_play:
+            if self.datatype == "fmsongs":
+                self.player.end_callback = self.fm_callback
+            else:
+                self.player.end_callback = None
+            self.storage.database['player_info']['idx'] = -1
+            self.player.play_and_pause(self.index)
+            self.resume_play = False
+
+    def song_changed_callback(self):
+        if self.at_playing_list:
+            self.show_playing_list()
 
     def fm_callback(self):
         log.debug("FM CallBack.")

--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -97,7 +97,7 @@ class Menu:
         self.storage.load()
         self.collection = self.storage.database['collections'][0]
         self.player = Player()
-        self.player.song_changed_callback = self.song_changed_callback
+        self.player.playing_song_changed_callback = self.song_changed_callback
         self.cache = Cache()
         self.ui = Ui()
         self.netease = NetEase()
@@ -393,7 +393,7 @@ class Menu:
 
             # 加载当前播放列表
             elif key == ord('p'):
-                self.show_playing_list()
+                self.show_playing_song()
 
 
             # 播放模式切换
@@ -586,7 +586,7 @@ class Menu:
                 self.title = '专辑搜索列表'
 
 
-    def show_playing_list(self):
+    def show_playing_song(self):
         if len(self.storage.database['player_info']['player_list']) == 0:
             return
         if not self.at_playing_list:
@@ -610,7 +610,7 @@ class Menu:
 
     def song_changed_callback(self):
         if self.at_playing_list:
-            self.show_playing_list()
+            self.show_playing_song()
 
     def fm_callback(self):
         log.debug("FM CallBack.")

--- a/NEMbox/player.py
+++ b/NEMbox/player.py
@@ -50,6 +50,7 @@ class Player:
         self.notifier = self.config.get_item("notifier")
         self.mpg123_parameters = self.config.get_item("mpg123_parameters")
         self.end_callback = None
+        self.song_changed_callback = None
 
     def popen_recall(self, onExit, popenArgs):
         """
@@ -299,6 +300,8 @@ class Player:
             self.info["idx"] = self.info["playing_list"][self.info["ridx"]]
         else:
             self.info["idx"] += 1
+        if self.song_changed_callback is not None:
+            self.song_changed_callback()
 
     def next(self):
         self.stop()
@@ -336,6 +339,8 @@ class Player:
             self.info["idx"] = self.info["playing_list"][self.info["ridx"]]
         else:
             self.info["idx"] -= 1
+        if self.song_changed_callback is not None:
+            self.song_changed_callback()
 
     def prev(self):
         self.stop()

--- a/NEMbox/player.py
+++ b/NEMbox/player.py
@@ -50,7 +50,7 @@ class Player:
         self.notifier = self.config.get_item("notifier")
         self.mpg123_parameters = self.config.get_item("mpg123_parameters")
         self.end_callback = None
-        self.song_changed_callback = None
+        self.playing_song_changed_callback = None
 
     def popen_recall(self, onExit, popenArgs):
         """
@@ -300,8 +300,8 @@ class Player:
             self.info["idx"] = self.info["playing_list"][self.info["ridx"]]
         else:
             self.info["idx"] += 1
-        if self.song_changed_callback is not None:
-            self.song_changed_callback()
+        if self.playing_song_changed_callback is not None:
+            self.playing_song_changed_callback()
 
     def next(self):
         self.stop()
@@ -339,8 +339,8 @@ class Player:
             self.info["idx"] = self.info["playing_list"][self.info["ridx"]]
         else:
             self.info["idx"] -= 1
-        if self.song_changed_callback is not None:
-            self.song_changed_callback()
+        if self.playing_song_changed_callback is not None:
+            self.playing_song_changed_callback()
 
     def prev(self):
         self.stop()

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -51,10 +51,16 @@ class Ui:
 
     def notify(self, summary, song, album, artist):
         if summary != "disable":
+            cmd = ""
             if platform.system() == "Darwin":
-                os.system('/usr/bin/osascript -e \'display notification "' + summary + ' ' + song + '\nin ' + album + ' by ' + artist +'"\'')
+                cmd = '/usr/bin/osascript -e $\'display notification "' + summary + ' ' + song.replace('\'', "\\\'") + '\nin ' + album + ' by ' + artist +'"\''
             else:
-                os.system('/usr/bin/notify-send "' + summary + song + ' in ' + album + ' by ' + artist + '"')
+                cmd = '/usr/bin/notify-send "' + summary + song.replace('\'', "\x27") + ' in ' + album + ' by ' + artist + '"'
+
+            log.debug(cmd)
+            os.system(cmd)
+
+
 
     def build_playinfo(self, song_name, artist, album_name, quality, start, pause=False):
         curses.noecho()

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -19,7 +19,7 @@ from scrollstring import *
 from storage import Storage
 import logger
 import os, platform
-import subprocess
+
 log = logger.getLogger(__name__)
 
 

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -19,9 +19,12 @@ from scrollstring import *
 from storage import Storage
 import logger
 import os, platform
-
+import subprocess
 log = logger.getLogger(__name__)
 
+
+def escape_quote(text):
+    return text.replace('\'', '\\\'').replace('\"', '\'\'')
 
 class Ui:
     def __init__(self):
@@ -52,14 +55,13 @@ class Ui:
     def notify(self, summary, song, album, artist):
         if summary != "disable":
             cmd = ""
+            content = escape_quote("%s %s\nin %s by %s" % (summary, song, album, artist))
             if platform.system() == "Darwin":
-                cmd = '/usr/bin/osascript -e $\'display notification "' + summary + ' ' + song.replace('\'', "\\\'") + '\nin ' + album + ' by ' + artist +'"\''
+                cmd = '/usr/bin/osascript -e $\'display notification "' + content + '"\''
             else:
-                cmd = '/usr/bin/notify-send "' + summary + song.replace('\'', "\x27") + ' in ' + album + ' by ' + artist + '"'
+                cmd = '/usr/bin/notify-send "' + content + '"'
 
-            log.debug(cmd)
             os.system(cmd)
-
 
 
     def build_playinfo(self, song_name, artist, album_name, quality, start, pause=False):


### PR DESCRIPTION
### Playing song improvement

If a song is played to the end or ']'  is pressed , playing song will be the next of the playing_list. If ui is still "at_playing_list", the highlight row will be updated to the current playing song.For example, if the current playing song is “好好的”
![current](http://ww4.sinaimg.cn/large/d6cc2d09jw1exw2ay19bnj21ec0t278v.jpg)
 then if user press ']' and if the playing mode is sequence, then “红色高跟鞋” will be highlighted.
![next](http://ww3.sinaimg.cn/large/d6cc2d09jw1exw2difxbfj21ec0t2jw3.jpg)

### Notification bug fix
if there exist a single quote in the song name or album name or artist name, like I'll show you, the notification will not work, and some error message will be printed on the screen because of the escape problem. Like the following image.
![error](http://ww3.sinaimg.cn/large/d6cc2d09jw1exw29n79d7j20z80t2n2c.jpg)
the single quotation mark can be escaped by replace it to \', and should put a $ before the string to indicate we want to use escape in the string, but double quotation mark problem can not be solved by replace it to \" , I think it is because of the weird syntax of the osascript. I just find a way around for now, that is to replace a double quotation mark to two single quotation marks, and they look similar and won't print the error message on the screen. Maybe other guys could find a better solution.

