### PR TITLE
Modify notify-send message

### DIFF
--- a/NEMbox/player.py
+++ b/NEMbox/player.py
@@ -143,9 +143,7 @@ class Player:
         item = self.songs[self.info["player_list"][self.info["idx"]]]
         self.ui.build_playinfo(item['song_name'], item['artist'], item['album_name'], item['quality'], time.time())
         if self.notifier == True:
-            self.ui.notify("Now playing: ", item['song_name'], item['album_name'], item['artist'])
-        else:
-            self.ui.notify("disable", item['song_name'], item['album_name'], item['artist'])
+            self.ui.notify("Now playing", item['song_name'], item['album_name'], item['artist'])
         self.playing_id = item['song_id']
         self.popen_recall(self.recall, item)
 

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -55,12 +55,12 @@ class Ui:
     def notify(self, summary, song, album, artist):
         if summary != "disable":
             cmd = ""
-            content = "%s %s\nin %s by %s" % (summary, song, album, artist)
+            body = "%s\nin %s by %s" % (song, album, artist)
             if platform.system() == "Darwin":
-                content = escape_quote(content)
+                content = escape_quote(summary + ': ' + body)
                 cmd = '/usr/bin/osascript -e $\'display notification "' + content + '"\''
             else:
-                cmd = '/usr/bin/notify-send "' + content + '"'
+                cmd = '/usr/bin/notify-send -a NetEase-MusicBox "%s" "%s"' % (summary, body)
 
             os.system(cmd)
 


### PR DESCRIPTION
Add app name
Put song info into message body

在 GNOME 3 上面显示效果更好了一点，解决了专辑名和歌手名显示不全的问题。其他桌面环境欢迎测试～