### PR TITLE
Built-in function pow are more efficiently than x ^ y % z.

### DIFF
--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -132,7 +132,7 @@ def aesEncrypt(text, secKey):
 
 def rsaEncrypt(text, pubKey, modulus):
     text = text[::-1]
-    rs = int(text.encode('hex'), 16) ** int(pubKey, 16) % int(modulus, 16)
+    rs = pow(int(text.encode('hex'), 16),  int(pubKey, 16), int(modulus, 16))
     return format(rs, 'x').zfill(256)
 
 


### PR DESCRIPTION
用内置的快速幂取模函数来加密，效率会更高些。以下改进前和改进后运行的时间：

```bash
$ python test.py
NEW: --- 0.0 seconds ---
OLD: --- 5.15600013733 seconds ---
True

$ python test.py
NEW: --- 0.0 seconds ---
OLD: --- 5.16900014877 seconds ---
True

$ python test.py
NEW: --- 0.0 seconds ---
OLD: --- 5.17399978638 seconds ---
True
```

文档：https://docs.python.org/2/library/functions.html#pow