### PR TITLE
rm include_package_data=True

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     name='NetEase-MusicBox',
     version='0.2.1.8',
     packages=find_packages(),
-    include_package_data=True,
     install_requires=[
         'requests',
         'BeautifulSoup4',


### PR DESCRIPTION
@darknessomi 
之前出错是因为没有这个参数就无法获取到 `requirements.txt` 文件。

```
HERE = os.path.abspath(os.path.dirname(__file__))
def get_install_requires(filename):
    req = []
    path = os.path.join(HERE, filename)
    # 这个判断导致找不到 requirements.txt 时返回空列表。
    # 你问我为啥会有这个判断，因为有的包没有本身没有依赖呀orz
    if os.path.exists(path):
        with open(path) as f:
            req = [l.strip() for l in f.xreadlines() if not l.isspace()]
    return req
```

我之前的这个写法没测出bug是因为我一直都是直接用 python setup.py install 或者 python setup.py develop 测试（目录下必然存在`requirements.txt`文件）。

查了下资料，不推荐通用`requirements.txt`文件内容和`install_requires`，所以干脆就不用了。
ref: http://python-packaging-user-guide.readthedocs.org/en/latest/requirements/

既然不需要`requirements.txt`文件了，那么`include_package_data=True`也就不需要了。
ps: 猜测官方默认设置这个为False大概是希望Python的包会比较纯粹？不晓得。