### PR TITLE
fix limit param of search api

### DIFF
--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -341,7 +341,7 @@ class NetEase:
             'type': stype,
             'offset': offset,
             'total': total,
-            'limit': 60
+            'limit': limit
         }
         return self.httpRequest('POST', action, data)
 


### PR DESCRIPTION
param `limit` of search api is always set to `60`, this pr will fix it.

@darknessomi please review.