### PR TITLE
[Fix] deprecate keybinder

### DIFF
--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -40,8 +40,8 @@ from . import logger
 log = logger.getLogger(__name__)
 
 try:
-    import keybinder
-    BINDABLE = True
+    # import keybinder
+    BINDABLE = False
 except ImportError:
     BINDABLE = False
     log.warn('keybinder module not installed.')


### PR DESCRIPTION
keybinder is written in C and Python 2.5, which introduces lots of potential GTK error like #361 #362 #353 

@darknessomi 

PS.

May we use TravisCI to automatically deploy package on PyPi?