### PR TITLE
[fix]全局快捷键失效

### DIFF
--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -40,8 +40,8 @@ from . import logger
 log = logger.getLogger(__name__)
 
 try:
-    # import keybinder
-    BINDABLE = False
+    import keybinder
+    BINDABLE = True
 except ImportError:
     BINDABLE = False
     log.warn('keybinder module not installed.')


### PR DESCRIPTION
在ubuntu下安装全局快捷键依赖包：sudo apt-get install python-keybinder
然后在config.py文件中设置想使用的快捷键。

目前支持3个快捷键：播放&暂停，下一曲，上一曲
可在menu.py的bind_keys()函数中添加