### PR TITLE
fix music url to open

### DIFF
--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -588,7 +588,7 @@ class Menu(object):
 
             elif key == ord('i'):
                 if self.player.playing_id != -1:
-                    webbrowser.open_new_tab('http://music.163.com/#/song?id=' +
+                    webbrowser.open_new_tab('http://music.163.com/song?id=' +
                                             str(self.player.playing_id))
 
             self.ui.build_process_bar(


### PR DESCRIPTION
主要是为了方便复制出去的链接能被其他链接预览服务抓取歌曲信息。