### PR TITLE
网易云音乐登陆地址更新

### DIFF
--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -249,7 +249,15 @@ class NetEase(object):
         pattern = re.compile(r'^0\d{2,3}\d{7,8}$|^1[34578]\d{9}$')
         if pattern.match(username):
             return self.phone_login(username, password)
-        action = 'https://music.163.com/weapi/login/'
+        action = 'https://music.163.com/weapi/login?csrf_token='
+        self.session.cookies.load()
+        csrf = ''
+        for cookie in self.session.cookies:
+            if cookie.name == '__csrf':
+                csrf = cookie.value
+        if csrf == '':
+            return False
+        action += csrf
         text = {
             'username': username,
             'password': password,


### PR DESCRIPTION
网易云音乐登陆地址已更新，原地址为：'https://music.163.com/weapi/login/' ，  
更新后地址为：action = 'https://music.163.com/weapi/login?csrf_token='，
 csrf_token从session中获取，经测试，csrf_token为空时也可登陆。