### PR TITLE
仅当窗口大小改变的时候调整terminal的大小

### DIFF
--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -598,8 +598,11 @@ class Ui(object):
     def update_size(self):
         # get terminal size
         size = terminalsize.get_terminal_size()
-        self.x = max(size[0], 10)
-        self.y = max(size[1], 25)
+        x = max(size[0], 10)
+        y = max(size[1], 25)
+        if (x, y) == (self.x, self.y): # no need to resize
+            return
+        self.x, self.y = x, y
 
         # update intendations
         curses.resizeterm(self.y, self.x)


### PR DESCRIPTION
原来的UI在即使窗口大小没有改变的情况下也会每隔500ms调用 curses.resizeterm， 致使 ncurses 重绘整个窗口，导致终端历史被刷屏，并且增加终端的 CPU 占用率。这个 PR 修正了这个问题。