### PR TITLE
add config for osdlyrics background area size

### DIFF
--- a/NEMbox/config.py
+++ b/NEMbox/config.py
@@ -26,7 +26,7 @@ class Config(Singleton):
         self._init = True
         self.config_file_path = Constant.config_path
         self.default_config = {
-            'version': 7,
+            'version': 8,
             'cache': {
                 'value': False,
                 'default': False,
@@ -93,6 +93,11 @@ class Config(Singleton):
                 'value': [225, 248, 113],
                 'default': [225, 248, 113],
                 'describe': 'Desktop lyrics RGB Color.'
+            },
+            'osdlyrics_size': {
+                'value': [600, 60],
+                'default': [600, 60],
+                'describe': 'Desktop lyrics area size.'
             },
             'osdlyrics_font': {
                 'value': ['Decorative', 16],
@@ -223,6 +228,13 @@ class Config(Singleton):
                     'value': False,
                     'default': False,
                     'describe': 'Set true to make curses transparency.'
+                }
+            elif self.config['version'] == 7:
+                self.config['version'] = 8
+                self.config['osdlyrics_size'] = {
+                    'value': [600, 60],
+                    'default': [600, 60],
+                    'describe': 'Desktop lyrics area size.'
                 }
             self.check_version()
             return False

--- a/NEMbox/osdlyrics.py
+++ b/NEMbox/osdlyrics.py
@@ -52,7 +52,8 @@ if pyqt_activity:
             else:
                 self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
             self.setMinimumSize(600, 50)
-            self.resize(600, 60)
+            osdlyrics_size = config.get_item("osdlyrics_size")
+            self.resize(osdlyrics_size[0], osdlyrics_size[1])
             scn = QtGui.QApplication.desktop().screenNumber(
                 QtGui.QApplication.desktop().cursor().pos())
             bl = QtGui.QApplication.desktop().screenGeometry(scn).bottomLeft()


### PR DESCRIPTION
Osdlyrics area is too small in hidpi screen,  such as my Thinkpad (2560*1440), Specially the height is not enough，so I add the config to control the osdlyrics area size.