### PR TITLE
[fix] 搜索时报 UnicodeWarning

### DIFF
--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -602,6 +602,7 @@ class Ui(object):
                     curses.color_pair(1))
         self.screen.refresh()
         info = self.screen.getstr(10, self.startcol, 60)
+        info = info.decode('utf8')
         if info == '':
             return '/return'
         elif info.strip() is '':


### PR DESCRIPTION
搜索时会有如图的警告：
![image](https://cloud.githubusercontent.com/assets/2339647/24994593/1d18abbc-205e-11e7-84b4-d96c2778d18a.png)
