### PR TITLE
Moves argument parsing into start

### DIFF
--- a/NEMbox/__init__.py
+++ b/NEMbox/__init__.py
@@ -21,6 +21,20 @@ version = "0.2.4.0"
 
 
 def start():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-v",
+                        "--version",
+                        help="show this version and exit",
+                        action="store_true")
+    args = parser.parse_args()
+    if args.version:
+        latest = Menu().check_version()
+        curses.endwin()
+        print('NetEase-MusicBox installed version:' + version)
+        if latest != version:
+            print('NetEase-MusicBox latest version:' + str(latest))
+        sys.exit()
+
     nembox_menu = Menu()
     try:
         nembox_menu.start_fork(version)
@@ -35,17 +49,3 @@ def start():
 
 if __name__ == '__main__':
     start()
-
-parser = argparse.ArgumentParser()
-parser.add_argument("-v",
-                    "--version",
-                    help="show this version and exit",
-                    action="store_true")
-args = parser.parse_args()
-if args.version:
-    latest = Menu().check_version()
-    curses.endwin()
-    print('NetEase-MusicBox installed version:' + version)
-    if latest != version:
-        print('NetEase-MusicBox latest version:' + str(latest))
-    sys.exit()


### PR DESCRIPTION
现有的命令行参数解析是在包导入时做的，会影响到试图 import 这个包的外部用户。