### PR TITLE
fix a bug related to num key

### DIFF
--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -297,7 +297,7 @@ class Menu(object):
 
             # 数字快捷键
             elif ord('0') <= key <= ord('9'):
-                idx = key - ord('0')
+                idx = self.index + key - ord('0')
                 self.ui.build_menu(self.datatype, self.title, self.datalist,
                                    self.offset, idx, self.step, self.START)
                 self.ui.build_loading()

--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # @Author: omi
 # @Date:   2014-08-24 21:51:57
+
 '''
 网易云音乐 Menu
 '''


### PR DESCRIPTION
(I cannot type Chinese now, sorry about that)
Greetings, when I use this app, I spotted a bug: when I use the num key after I move to the next page, the inner content does not match. So I read the source code and remove this bug.

Please check whether the bug still appears.