### PR TITLE
fix:修复了 精选歌单>分类精选 功能下,lxml包依赖的缺失

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
         'requests',
         'BeautifulSoup4',
         'pycrypto',
-        'future'
+        'future',
+        'lxml'
     ],
 
     entry_points={


### PR DESCRIPTION
感谢命令行版网易云~, 体验感很不错~, 修改了一点小的bug, 使用到精选歌单分类下的分类精选功能时，会提示lxml包依赖缺失，在install_requires中依赖缺失lxml, 特补充完整.