### PR TITLE
[fix]:修正了中文字符计算错误的问题.[new_feature]:关于前进操作的小修改.

### DIFF
--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -129,6 +129,7 @@ class Menu(object):
         self.username = self.storage.database['user']['nickname']
         self.resume_play = True
         self.at_playing_list = False
+        self.enter_flag = True
         signal.signal(signal.SIGWINCH, self.change_term)
         signal.signal(signal.SIGINT, self.send_kill)
         self.START = time.time()
@@ -327,13 +328,15 @@ class Menu(object):
 
             # 前进
             elif key == ord('l') or key == 10:
+                self.enter_flag = True
                 if len(self.datalist) <= 0:
                     continue
                 self.START = time.time()
                 self.ui.build_loading()
                 self.dispatch_enter(idx)
-                self.index = 0
-                self.offset = 0
+                if self.enter_flag is True:
+                    self.index = 0
+                    self.offset = 0
 
             # 回退
             elif key == ord('h'):
@@ -751,6 +754,16 @@ class Menu(object):
                 self.datatype = 'albums'
                 self.datalist = ui.build_search('albums')
                 self.title = '专辑搜索列表'
+
+        else:
+            stack = self.stack
+            up = stack.pop()
+            self.datatype = up[0]
+            self.title = up[1]
+            self.datalist = up[2]
+            self.offset = up[3]
+            self.index = idx
+            self.enter_flag = False
 
     def show_playing_song(self):
         if self._is_playlist_empty():

--- a/NEMbox/scrollstring.py
+++ b/NEMbox/scrollstring.py
@@ -55,4 +55,4 @@ def truelen(string):
     >>> truelen('')
     0
     """
-    return len(string) - sum(1 for c in string if c > chr(127)) / 3
+    return len(string) + sum(1 for c in string if c > chr(127))


### PR DESCRIPTION
2017-12-12：
您好，还是感谢musicbox带来的流畅体验~，但使用过程中发现，有些名字过长的音乐名不会滚动播放，发现关于中文字符长度的计算问题，特将此修正。
2017-12-13：
哈，真是爱死musicbox了。刚刚发现如果前进目录已经为空了，还是会执行一次前进操作，同时还可以执行一次多余的回退操作，感觉这样对于用户的体验感不是很好，所以我尝试着将这个功能小小地修正了一下，如果前进目录不存的话，就忽略此次前进操作了。thx