### PR TITLE
修复Issue#601双行翻译歌词的问题

### DIFF
--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -217,12 +217,12 @@ class Ui(object):
                         self.now_lyric = line
                     else:
                         self.now_lyric = line
-                        for tline in song['tlyric']:
+                        for tindex, tline in enumerate(song['tlyric']):
                             if key in tline and self.config.get_item(
                                     'translation'):
                                 self.now_lyric = tline + ' || ' + self.now_lyric  # NOQA
-                                if not (self.post_lyric == ''):
-                                    self.post_lyric = tline + ' || ' + self.post_lyric
+                                if not (self.post_lyric == '') and tindex < len(song['tlyric']) -1:
+                                    self.post_lyric = song['tlyric'][tindex+1] + ' || ' + self.post_lyric
                                 #此处已经拿到，直接break即可
                                 break
                     #此处已经拿到，直接break即可


### PR DESCRIPTION
翻译后的语句是`tline`，但是两个`tline`显然是一样的，这造成了翻译歌词显示的错误。
两行不同的歌词，中文翻译总是一样的。
***
修复前效果：
![修复前效果](https://user-images.githubusercontent.com/6873988/29491940-0e51931e-859e-11e7-93b9-762a2af98340.png)
修复后效果：
![修复后效果](https://ws1.sinaimg.cn/large/006tNc79ly1fmnb1nwayaj31ck0h8n35.jpg)