### PR TITLE
修复不能登陆的Bug, 增加QT5支持

### DIFF
--- a/NEMbox/osdlyrics.py
+++ b/NEMbox/osdlyrics.py
@@ -18,17 +18,28 @@ log = logger.getLogger(__name__)
 
 config = Config()
 
+pyqt_activity = False
 try:
-    from PyQt4 import QtGui, QtCore, QtDBus
+    from PyQt5 import QtGui, QtCore, QtDBus, QtWidgets
+    QWidget = QtWidgets.QWidget
+    QApplication = QtWidgets.QApplication
+    delta = lambda e: e.angleDelta().x() + e.angleDelta().y()
+
     pyqt_activity = True
 except ImportError:
-    pyqt_activity = False
-    log.warn("PyQt4 module not installed.")
-    log.warn("Osdlyrics Not Available.")
+    try:
+        from PyQt4 import QtGui, QtCore, QtDBus
+        QWidget = QtGui.QWidget
+        QApplication = QtGui.QApplication
+        delta = lambda e: e.delta()
+        pyqt_activity = True
+    except ImportError:
+        log.warn("Neither PyQt5 or PyQt4 module installed.")
+        log.warn("Osdlyrics Not Available.")
 
 if pyqt_activity:
 
-    class Lyrics(QtGui.QWidget):
+    class Lyrics(QWidget):
 
         def __init__(self):
             super(Lyrics, self).__init__()
@@ -36,26 +47,26 @@ if pyqt_activity:
             self.initUI()
 
         def initUI(self):
-            self.setStyleSheet("background:" + config.get(
+            self.setStyleSheet("background:" + config.get_item(
                 "osdlyrics_background"))
-            if config.get("osdlyrics_transparent"):
+            if config.get_item("osdlyrics_transparent"):
                 self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
             self.setAttribute(QtCore.Qt.WA_ShowWithoutActivating)
             self.setAttribute(QtCore.Qt.WA_X11DoNotAcceptFocus)
             self.setFocusPolicy(QtCore.Qt.NoFocus)
-            if config.get("osdlyrics_on_top"):
+            if config.get_item("osdlyrics_on_top"):
                 self.setWindowFlags(QtCore.Qt.FramelessWindowHint |
                                     QtCore.Qt.WindowStaysOnTopHint |
                                     QtCore.Qt.X11BypassWindowManagerHint)
             else:
                 self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
             self.setMinimumSize(600, 50)
-            osdlyrics_size = config.get("osdlyrics_size")
+            osdlyrics_size = config.get_item("osdlyrics_size")
             self.resize(osdlyrics_size[0], osdlyrics_size[1])
-            scn = QtGui.QApplication.desktop().screenNumber(
-                QtGui.QApplication.desktop().cursor().pos())
-            bl = QtGui.QApplication.desktop().screenGeometry(scn).bottomLeft()
-            br = QtGui.QApplication.desktop().screenGeometry(scn).bottomRight()
+            scn = QApplication.desktop().screenNumber(
+                QApplication.desktop().cursor().pos())
+            bl = QApplication.desktop().screenGeometry(scn).bottomLeft()
+            br = QApplication.desktop().screenGeometry(scn).bottomRight()
             bc = (bl + br) / 2
             frameGeo = self.frameGeometry()
             frameGeo.moveCenter(bc)
@@ -75,7 +86,7 @@ if pyqt_activity:
                 self.move(newpos)
 
         def wheelEvent(self, event):
-            self.resize(self.width() + event.delta(), self.height())
+            self.resize(self.width() + delta(event), self.height())
 
         def paintEvent(self, event):
             qp = QtGui.QPainter()
@@ -84,8 +95,8 @@ if pyqt_activity:
             qp.end()
 
         def drawText(self, event, qp):
-            osdlyrics_color = config.get("osdlyrics_color")
-            osdlyrics_font = config.get("osdlyrics_font")
+            osdlyrics_color = config.get_item("osdlyrics_color")
+            osdlyrics_font = config.get_item("osdlyrics_font")
             font = QtGui.QFont(osdlyrics_font[0], osdlyrics_font[1])
             pen = QtGui.QColor(osdlyrics_color[0], osdlyrics_color[1],
                                osdlyrics_color[2])
@@ -114,7 +125,7 @@ if pyqt_activity:
 
     def show_lyrics():
 
-        app = QtGui.QApplication(sys.argv)
+        app = QApplication(sys.argv)
         lyrics = Lyrics()
         QtDBus.QDBusConnection.sessionBus().registerService('org.musicbox.Bus')
         QtDBus.QDBusConnection.sessionBus().registerObject('/', lyrics)
@@ -122,7 +133,7 @@ if pyqt_activity:
 
 
 def show_lyrics_new_process():
-    if pyqt_activity and config.get("osdlyrics"):
+    if pyqt_activity and config.get_item("osdlyrics"):
         p = Process(target=show_lyrics)
         p.daemon = True
         p.start()

--- a/NEMbox/osdlyrics.py
+++ b/NEMbox/osdlyrics.py
@@ -47,21 +47,21 @@ if pyqt_activity:
             self.initUI()
 
         def initUI(self):
-            self.setStyleSheet("background:" + config.get_item(
+            self.setStyleSheet("background:" + config.get(
                 "osdlyrics_background"))
-            if config.get_item("osdlyrics_transparent"):
+            if config.get("osdlyrics_transparent"):
                 self.setAttribute(QtCore.Qt.WA_TranslucentBackground)
             self.setAttribute(QtCore.Qt.WA_ShowWithoutActivating)
             self.setAttribute(QtCore.Qt.WA_X11DoNotAcceptFocus)
             self.setFocusPolicy(QtCore.Qt.NoFocus)
-            if config.get_item("osdlyrics_on_top"):
+            if config.get("osdlyrics_on_top"):
                 self.setWindowFlags(QtCore.Qt.FramelessWindowHint |
                                     QtCore.Qt.WindowStaysOnTopHint |
                                     QtCore.Qt.X11BypassWindowManagerHint)
             else:
                 self.setWindowFlags(QtCore.Qt.FramelessWindowHint)
             self.setMinimumSize(600, 50)
-            osdlyrics_size = config.get_item("osdlyrics_size")
+            osdlyrics_size = config.get("osdlyrics_size")
             self.resize(osdlyrics_size[0], osdlyrics_size[1])
             scn = QApplication.desktop().screenNumber(
                 QApplication.desktop().cursor().pos())
@@ -95,8 +95,8 @@ if pyqt_activity:
             qp.end()
 
         def drawText(self, event, qp):
-            osdlyrics_color = config.get_item("osdlyrics_color")
-            osdlyrics_font = config.get_item("osdlyrics_font")
+            osdlyrics_color = config.get("osdlyrics_color")
+            osdlyrics_font = config.get("osdlyrics_font")
             font = QtGui.QFont(osdlyrics_font[0], osdlyrics_font[1])
             pen = QtGui.QColor(osdlyrics_color[0], osdlyrics_color[1],
                                osdlyrics_color[2])
@@ -133,7 +133,7 @@ if pyqt_activity:
 
 
 def show_lyrics_new_process():
-    if pyqt_activity and config.get_item("osdlyrics"):
+    if pyqt_activity and config.get("osdlyrics"):
         p = Process(target=show_lyrics)
         p.daemon = True
         p.start()

--- a/NEMbox/storage.py
+++ b/NEMbox/storage.py
@@ -84,12 +84,12 @@ class Storage(Singleton):
         self.cookie_path = Constant.cookie_path
 
     def login(self, username, password, userid, nickname):
-        self.database.update(dict(
+        self.database['user'] = dict(
             username=username,
             password=password,
             user_id=userid,
             nickname=nickname
-        ))
+        )
 
     def logout(self):
         self.database['user'] = {


### PR DESCRIPTION
在最近的版本中发现一直出现登陆界面，发现问题是由于userid直接保存在了storage中的database下，而其他代码假定userid应保存在database['user']中。修复这个问题。
增加了在安装了Qt5的系统中使用Qt5展示桌面歌词的功能。