### PR TITLE
修复播放和显示歌曲不一致，修复加载某些歌手名为 None 的歌曲导致崩溃的问题

### DIFF
--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -121,7 +121,19 @@ class Parse(object):
         artist = ''
         # 对新老接口进行处理
         if 'ar' in song:
-            artist = ', '.join([a['name'] for a in song['ar']])
+            artist = ', '.join([a['name'] for a in song['ar'] if a['name'] is not None])
+            # 某些云盘的音乐会出现 'ar' 的 'name' 为 None 的情况
+            # 不过会多个 ’pc' 的字段
+            # {'name': '简单爱', 'id': 31393663, 'pst': 0, 't': 1, 'ar': [{'id': 0, 'name': None, 'tns': [], 'alias': []}],
+            #  'alia': [], 'pop': 0.0, 'st': 0, 'rt': None, 'fee': 0, 'v': 5, 'crbt': None, 'cf': None,
+            #  'al': {'id': 0, 'name': None, 'picUrl': None, 'tns': [], 'pic': 0}, 'dt': 273000, 'h': None, 'm': None,
+            #  'l': {'br': 193000, 'fid': 0, 'size': 6559659, 'vd': 0.0}, 'a': None, 'cd': None, 'no': 0, 'rtUrl': None,
+            #  'ftype': 0, 'rtUrls': [], 'djId': 0, 'copyright': 0, 's_id': 0, 'rtype': 0, 'rurl': None, 'mst': 9,
+            #  'cp': 0, 'mv': 0, 'publishTime': 0,
+            #  'pc': {'nickname': '', 'br': 192, 'fn': '简单爱.mp3', 'cid': '', 'uid': 41533322, 'alb': 'The One 演唱会',
+            #         'sn': '简单爱', 'version': 2, 'ar': '周杰伦'}, 'url': None, 'br': 0}
+            if artist == '' and 'pc' in song:
+                artist = '未知艺术家' if song['pc']['ar'] is None else song['pc']['ar']
         elif 'artists' in song:
             artist = ', '.join([a['name'] for a in song['artists']])
         else:


### PR DESCRIPTION
播放和显示歌曲不一致是因为网站 api 返回的 urls 的 id 顺序和 data 的 id 顺序不一致

我自己的列表中有些云盘的歌曲歌手名是 None，会导致程序崩溃
{'name': '嘻哈空姐', 'id': 31393802, 'pst': 0, 't': 1, 'ar': [{'id': 0, 'name': None, 'tns': [], 'alias': []}], 'alia': [], 'pop': 0.0, 'st': 0, 'rt': None, 'fee': 0, 'v': 7, 'crbt': None, 'cf': None, 'al': {'id': 0, 'name': None, 'picUrl': None, 'tns': [], 'pic': 0}, 'dt': 168000, 'h': None, 'm': None, 'l': {'br': 192000, 'fid': 0, 'size': 4046262, 'vd': 0.0}, 'a': None, 'cd': None, 'no': 0, 'rtUrl': None, 'ftype': 0, 'rtUrls': [], 'djId': 0, 'copyright': 0, 's_id': -185674, 'mst': 9, 'cp': 0, 'mv': 0, 'rtype': 0, 'rurl': None, 'publishTime': 0, 'pc': {'nickname': '', 'version': 1, 'br': 192, 'cid': '', 'alb': '', 'sn': '嘻哈空姐', 'ar': '周杰伦', 'fn': '嘻哈空姐 www.is123.cn.mp3', 'uid': 41533322}, 'url': 'http://m10.music.126.net/20180612222749/eb87cbb62325acf0c65eec1d908d22b5/ymusic/7388/4959/15fe/c527fa6d0aee9373b53566ea76b6fa3e.mp3', 'br': 128000}