### PR TITLE
修复 Python 3 登录问题

### DIFF
--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -344,7 +344,7 @@ class NetEase(object):
             discard=False,
             comment=None,
             comment_url=None,
-            rest=None,
+            rest={},
         )
 
     def request(self, method, path, params={}, default={"code": -1}, custom_cookies={'os':'pc'}):


### PR DESCRIPTION
在 Cookie 中传入 `rest=None` 会在存储 cookie 时导致抛出异常。因为标准库期望 `rest` 是一个 dict-like： https://github.com/python/cpython/blob/f1f9c0c532089824791cfc18e6d6f29e1cd62596/Lib/http/cookiejar.py#L1846

Should fix https://github.com/darknessomi/musicbox/issues/824 and https://github.com/darknessomi/musicbox/issues/809