### PR TITLE
修复url获取失败播放器崩溃问题(#792)

### DIFF
--- a/NEMbox/player.py
+++ b/NEMbox/player.py
@@ -227,6 +227,10 @@ class Player(object):
         self.build_playinfo()
 
     def run_mpg123(self, on_exit, url, expires=-1, get_time=-1):
+        if url is None:
+            self.next()
+            return -1
+
         para = ["mpg123", "-R"] + self.config_mpg123
         self.popen_handler = subprocess.Popen(
             para, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -320,7 +324,7 @@ class Player(object):
             )
         else:
             new_url = NetEase().songs_url([args["song_id"]])[0]["url"]  #使用新地址
-            if  not new_url:    #如果没有获得新地址
+            if not new_url:    #如果没有获得新地址
                 new_url = args["mp3_url"]  #使用老地址传给mpg123
             thread = threading.Thread(
                 target=self.run_mpg123,


### PR DESCRIPTION
部分歌曲获取url会得到`None`值引发bug。