### PR TITLE
Fix volume_up shortcuts

### DIFF
--- a/NEMbox/config.py
+++ b/NEMbox/config.py
@@ -178,7 +178,7 @@ class Config(Singleton):
                     "jumpIndex": "G",
                     "playPause": " ",
                     "shuffle": "?",
-                    "volume+": "+",
+                    "volume+": "=",
                     "volume-": "-",
                     "menu": "m",
                     "presentHistory": "p",


### PR DESCRIPTION
Simply use '=' instead of '+', no need to press 'Shift' anymore.