### PR TITLE
docs: fix simple typo, scoll -> scroll

### DIFF
--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -411,7 +411,7 @@ class Ui(object):
                         datalist[i]["album_name"],
                     )
 
-                    # the length decides whether to scoll
+                    # the length decides whether to scroll
                     if truelen(name) < self.content_width:
                         self.addstr(
                             i - offset + 9,


### PR DESCRIPTION
There is a small typo in NEMbox/ui.py.

Should read `scroll` rather than `scoll`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md