### PR TITLE
针对主播电台的修复，添加搜索主播电台的功能

### DIFF
--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -536,11 +536,10 @@ class NetEase(object):
             return lyric.split("\n")
 
     # 今日最热（0）, 本周最热（10），历史最热（20），最新节目（30）
-    def djchannels(self, offset=0, limit=50):
+    def djRadios(self, offset=0, limit=50):
         path = "/weapi/djradio/hot/v1"
         params = dict(limit=limit, offset=offset)
-        channels = self.request("POST", path, params).get("djRadios", [])
-        return channels
+        return self.request("POST", path, params).get("djRadios", [])
 
     def djprograms(self, radio_id, asc=False, offset=0, limit=50):
         path = "/weapi/dj/program/byradio"
@@ -633,5 +632,8 @@ class NetEase(object):
 
         elif dig_type == "playlist_class_detail":
             return PLAYLIST_CLASSES[data]
+
+        elif dig_type == "djRadios":
+            return data
         else:
             raise ValueError("Invalid dig type")

--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -542,11 +542,20 @@ class NetEase(object):
         channels = self.request("POST", path, params).get("djRadios", [])
         return channels
 
-    def djprograms(self, radio_id, asc=False, offset=0, limit=100):
+    def djprograms(self, radio_id, asc=False, offset=0, limit=50):
         path = "/weapi/dj/program/byradio"
         params = dict(asc=asc, radioId=radio_id, offset=offset, limit=limit)
         programs = self.request("POST", path, params).get("programs", [])
         return [p["mainSong"] for p in programs]
+
+    def alldjprograms(self, radio_id, asc=False, offset=0, limit=500):
+        programs = []
+        ps = self.djprograms(radio_id, asc=asc, offset=offset, limit=limit)
+        while ps:
+            programs.extend(ps)
+            offset += limit
+            ps = self.djprograms(radio_id, asc=asc, offset=offset, limit=limit)
+        return programs
 
     # 获取版本
     def get_version(self):

--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -542,7 +542,7 @@ class NetEase(object):
         channels = self.request("POST", path, params).get("djRadios", [])
         return channels
 
-    def djprograms(self, radio_id, asc=False, offset=0, limit=50):
+    def djprograms(self, radio_id, asc=False, offset=0, limit=100):
         path = "/weapi/dj/program/byradio"
         params = dict(asc=asc, radioId=radio_id, offset=offset, limit=limit)
         programs = self.request("POST", path, params).get("programs", [])
@@ -560,14 +560,18 @@ class NetEase(object):
     def dig_info(self, data, dig_type):
         if not data:
             return []
-        if dig_type == "songs" or dig_type == "fmsongs":
+        if dig_type == "songs" or dig_type == "fmsongs" or dig_type == "djprograms":
             sids = [x["id"] for x in data]
             urls = self.songs_url(sids)
-            i = 0
-            sds = []
-            while i < len(sids):
-                sds.extend(self.songs_detail(sids[i : i + 500]))
-                i += 500
+            # songs_detail api会返回空的电台歌名，故使用原数据
+            if dig_type == "djprograms":
+                sds = data
+            else:
+                i = 0
+                sds = []
+                while i < len(sids):
+                    sds.extend(self.songs_detail(sids[i : i + 500]))
+                    i += 500
             timestamp = time.time()
             # api 返回的 urls 的 id 顺序和 data 的 id 顺序不一致
             # 为了获取到对应 id 的 url，对返回的 urls 做一个 id2index 的缓存

--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -576,12 +576,13 @@ class NetEase(object):
             urls = []
             for i in range(0, len(sids), 350):
                 for count in range(3):
-                    urls_group = self.songs_url(sids[i:i + 350])
-                    if urls_group: break
+                    urls_group = self.songs_url(sids[i : i + 350])
+                    if urls_group:
+                        urls.extend(urls_group)
+                        break
                 else:
                     log.error("self.songs_url return [], check network connection")
                     return []
-                urls.extend(urls_group)
             # songs_detail api会返回空的电台歌名，故使用原数据
             sds = []
             if dig_type == "djprograms":
@@ -589,7 +590,7 @@ class NetEase(object):
             # 支持超过1000首歌曲的歌单
             else:
                 for i in range(0, len(sids), 500):
-                    sds.extend(self.songs_detail(sids[i:i + 500]))
+                    sds.extend(self.songs_detail(sids[i : i + 500]))
             # api 返回的 urls 的 id 顺序和 data 的 id 顺序不一致
             # 为了获取到对应 id 的 url，对返回的 urls 做一个 id2index 的缓存
             # 同时保证 data 的 id 顺序不变

--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -575,14 +575,7 @@ class NetEase(object):
             # 导致日志记录大量can't get song url的可能原因
             urls = []
             for i in range(0, len(sids), 350):
-                for count in range(3):
-                    urls_group = self.songs_url(sids[i : i + 350])
-                    if urls_group:
-                        urls.extend(urls_group)
-                        break
-                else:
-                    log.error("self.songs_url return [], check network connection")
-                    return []
+                urls.extend(self.songs_url(sids[i : i + 350]))
             # songs_detail api会返回空的电台歌名，故使用原数据
             sds = []
             if dig_type == "djprograms":
@@ -603,7 +596,7 @@ class NetEase(object):
                 url_index = url_id_index.get(s["id"])
                 if url_index is None:
                     log.error("can't get song url, id: %s", s["id"])
-                    continue
+                    return []
                 s["url"] = urls[url_index]["url"]
                 s["br"] = urls[url_index]["br"]
                 s["expires"] = urls[url_index]["expi"]

--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -564,22 +564,23 @@ class NetEase(object):
             sids = [x["id"] for x in data]
             # 可能因网络波动，返回空值，在Parse.songs中引发KeyError
             # 导致日志记录大量can't get song url的可能原因
-            for count in range(3):
-                urls = self.songs_url(sids)
-                if urls: break
-            else:
-                log.error("urls is null, check network connection")
-                return []
+            urls = []
+            for i in range(0, len(sids), 350):
+                for count in range(3):
+                    urls_group = self.songs_url(sids[i:i + 350])
+                    if urls_group: break
+                else:
+                    log.error("self.songs_url return [], check network connection")
+                    return []
+                urls.extend(urls_group)
             # songs_detail api会返回空的电台歌名，故使用原数据
+            sds = []
             if dig_type == "djprograms":
-                sds = data
+                sds.extend(data)
             # 支持超过1000首歌曲的歌单
             else:
-                i = 0
-                sds = []
-                while i < len(sids):
-                    sds.extend(self.songs_detail(sids[i : i + 500]))
-                    i += 500
+                for i in range(0, len(sids), 500):
+                    sds.extend(self.songs_detail(sids[i:i + 500]))
             # api 返回的 urls 的 id 顺序和 data 的 id 顺序不一致
             # 为了获取到对应 id 的 url，对返回的 urls 做一个 id2index 的缓存
             # 同时保证 data 的 id 顺序不变

--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -611,7 +611,9 @@ class NetEase(object):
             return Parse.songs(sds)
 
         elif dig_type == "refresh_urls":
-            urls_info = self.songs_url(data)
+            urls_info = []
+            for i in range(0, len(data), 350):
+                urls_info.extend(self.songs_url(data[i : i + 350]))
             timestamp = time.time()
 
             songs = []

--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -1024,7 +1024,7 @@ class Menu(object):
             programs = netease.djprograms(radio_id)
             self.title += " > " + datalist[idx]["name"]
             self.datatype = "songs"
-            self.datalist = netease.dig_info(programs, "songs")
+            self.datalist = netease.dig_info(programs, "djprograms")
 
         # 该专辑包含的歌曲
         elif datatype == "albums":

--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -120,7 +120,7 @@ class Menu(object):
             {"entry_name": "新碟上架"},
             {"entry_name": "精选歌单"},
             {"entry_name": "我的歌单"},
-            {"entry_name": "今日最热主播电台"},
+            {"entry_name": "主播电台"},
             {"entry_name": "每日推荐歌曲"},
             {"entry_name": "每日推荐歌单"},
             {"entry_name": "私人FM"},
@@ -354,8 +354,8 @@ class Menu(object):
             self.player.end_callback = None
             self.player.play_or_pause(origin_index, self.at_playing_list)
             self.at_playing_list = False
-        elif datatype == "djchannels":
-            self.player.new_player_list("djchannels", title, datalist, -1)
+        elif datatype == "djprograms":
+            self.player.new_player_list("djprograms", title, datalist, -1)
             self.player.end_callback = None
             self.player.play_or_pause(origin_index, self.at_playing_list)
             self.at_playing_list = False
@@ -382,11 +382,11 @@ class Menu(object):
         # If change to a new playing list. Add playing list and play.
         datatype_callback = {
             "songs": None,
-            "djchannels": None,
+            "djprograms": None,
             "fmsongs": self.fm_callback,
         }
 
-        if datatype in ["songs", "djchannels", "fmsongs"]:
+        if datatype in ["songs", "djprograms", "fmsongs"]:
             self.player.new_player_list(datatype, self.title, self.datalist, -1)
             self.player.end_callback = datatype_callback[datatype]
             self.player.play_or_pause(idx, self.at_playing_list)
@@ -833,7 +833,9 @@ class Menu(object):
 
             # 添加到打碟歌单
             elif C.keyname(key).decode("utf-8") == KEY_MAP["add"]:
-                if datatype == "songs" and len(datalist) != 0:
+                if (self.datatype == "songs" or self.datatype == "djprograms") and len(
+                    self.datalist
+                ) != 0:
                     self.djstack.append(datalist[idx])
                 elif datatype == "artists":
                     pass
@@ -851,7 +853,7 @@ class Menu(object):
 
             # 添加到本地收藏
             elif C.keyname(key).decode("utf-8") == KEY_MAP["star"]:
-                if (self.datatype == "songs" or self.datatype == "djchannels") and len(
+                if (self.datatype == "songs" or self.datatype == "djprograms") and len(
                     self.datalist
                 ) != 0:
                     self.collection.append(self.datalist[self.index])
@@ -871,7 +873,7 @@ class Menu(object):
             # 从当前列表移除
             elif C.keyname(key).decode("utf-8") == KEY_MAP["remove"]:
                 if (
-                    self.datatype in ("songs", "djchannels", "fmsongs")
+                    self.datatype in ("songs", "djprograms", "fmsongs")
                     and len(self.datalist) != 0
                 ):
                     self.datalist.pop(self.index)
@@ -1023,7 +1025,7 @@ class Menu(object):
             radio_id = datalist[idx]["id"]
             programs = netease.djprograms(radio_id)
             self.title += " > " + datalist[idx]["name"]
-            self.datatype = "songs"
+            self.datatype = "djprograms"
             self.datalist = netease.dig_info(programs, "djprograms")
 
         # 该专辑包含的歌曲

--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -229,7 +229,7 @@ class Menu(object):
             "albums": SearchArg("搜索专辑：", 10, lambda datalist: datalist),
             "artists": SearchArg("搜索艺术家：", 100, lambda datalist: datalist),
             "playlists": SearchArg("搜索网易精选集：", 1000, lambda datalist: datalist),
-            "djchannels": SearchArg("搜索主播电台：", 1009, lambda datalist: datalist),
+            "djRadios": SearchArg("搜索主播电台：", 1009, lambda datalist: datalist),
         }
 
         prompt, api_type, post_process = category_map[category]
@@ -241,11 +241,8 @@ class Menu(object):
         if not data:
             return data
 
-        if category == "djchannels":
-            return post_process(data.get("djRadios", []))
-        else:
-            datalist = post_process(data.get(category, []))
-            return self.api.dig_info(datalist, category)
+        datalist = post_process(data.get(category, []))
+        return self.api.dig_info(datalist, category)
 
     def change_term(self, signum, frame):
         self.ui.screen.clear()
@@ -1021,7 +1018,7 @@ class Menu(object):
                 self.datatype = "albums"
                 self.datalist = netease.dig_info(albums, "albums")
 
-        elif datatype == "djchannels":
+        elif datatype == "djRadios":
             radio_id = datalist[idx]["id"]
             programs = netease.alldjprograms(radio_id)
             self.title += " > " + datalist[idx]["name"]
@@ -1122,7 +1119,7 @@ class Menu(object):
                 1: SearchCategory("songs", "歌曲搜索列表"),
                 2: SearchCategory("artists", "艺术家搜索列表"),
                 3: SearchCategory("albums", "专辑搜索列表"),
-                4: SearchCategory("djchannels", "主播电台搜索列表"),
+                4: SearchCategory("djRadios", "主播电台搜索列表"),
             }
             self.datatype, self.title = idx_map[idx]
             self.datalist = self.search(self.datatype)
@@ -1228,9 +1225,9 @@ class Menu(object):
             self.datalist = self.api.dig_info(myplaylist, self.datatype)
             self.title += " > " + self.username + " 的歌单"
         elif idx == 5:
-            self.datatype = "djchannels"
+            self.datatype = "djRadios"
             self.title += " > 主播电台"
-            self.datalist = self.api.djchannels()
+            self.datalist = self.api.djRadios()
         elif idx == 6:
             self.datatype = "songs"
             self.title += " > 每日推荐歌曲"

--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -489,7 +489,7 @@ class Menu(object):
         self.build_menu_processbar()
 
     def digit_key_song_event(self):
-        """ 直接跳到指定id 歌曲 """
+        """直接跳到指定id 歌曲"""
         step = self.step
         self.key_list.pop()
         song_index = parse_keylist(self.key_list)

--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -1023,7 +1023,7 @@ class Menu(object):
 
         elif datatype == "djchannels":
             radio_id = datalist[idx]["id"]
-            programs = netease.djprograms(radio_id)
+            programs = netease.alldjprograms(radio_id)
             self.title += " > " + datalist[idx]["name"]
             self.datatype = "djprograms"
             self.datalist = netease.dig_info(programs, "djprograms")

--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -120,7 +120,7 @@ class Menu(object):
             {"entry_name": "新碟上架"},
             {"entry_name": "精选歌单"},
             {"entry_name": "我的歌单"},
-            {"entry_name": "主播电台"},
+            {"entry_name": "今日最热主播电台"},
             {"entry_name": "每日推荐歌曲"},
             {"entry_name": "每日推荐歌单"},
             {"entry_name": "私人FM"},
@@ -229,6 +229,7 @@ class Menu(object):
             "albums": SearchArg("搜索专辑：", 10, lambda datalist: datalist),
             "artists": SearchArg("搜索艺术家：", 100, lambda datalist: datalist),
             "playlists": SearchArg("搜索网易精选集：", 1000, lambda datalist: datalist),
+            "djchannels": SearchArg("搜索主播电台：", 1009, lambda datalist: datalist),
         }
 
         prompt, api_type, post_process = category_map[category]
@@ -240,8 +241,11 @@ class Menu(object):
         if not data:
             return data
 
-        datalist = post_process(data.get(category, []))
-        return self.api.dig_info(datalist, category)
+        if category == "djchannels":
+            return post_process(data.get("djRadios", []))
+        else:
+            datalist = post_process(data.get(category, []))
+            return self.api.dig_info(datalist, category)
 
     def change_term(self, signum, frame):
         self.ui.screen.clear()
@@ -1116,6 +1120,7 @@ class Menu(object):
                 1: SearchCategory("songs", "歌曲搜索列表"),
                 2: SearchCategory("artists", "艺术家搜索列表"),
                 3: SearchCategory("albums", "专辑搜索列表"),
+                4: SearchCategory("djchannels", "主播电台搜索列表"),
             }
             self.datatype, self.title = idx_map[idx]
             self.datalist = self.search(self.datatype)
@@ -1243,7 +1248,7 @@ class Menu(object):
         elif idx == 9:
             self.datatype = "search"
             self.title += " > 搜索"
-            self.datalist = ["歌曲", "艺术家", "专辑", "网易精选集"]
+            self.datalist = ["歌曲", "艺术家", "专辑", "主播电台", "网易精选集"]
         elif idx == 10:
             self.datatype = "help"
             self.title += " > 帮助"

--- a/NEMbox/player.py
+++ b/NEMbox/player.py
@@ -460,7 +460,7 @@ class Player(object):
         self.add_songs(datalist)
 
     # switch_flag为true表示：
-    # 在播放列表中 || 当前所在列表类型不在"songs"、"djchannels"、"fmsongs"中
+    # 在播放列表中 || 当前所在列表类型不在"songs"、"djprograms"、"fmsongs"中
     def play_or_pause(self, idx, switch_flag):
         if self.is_empty:
             return

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -398,7 +398,7 @@ class Ui(object):
                         str(i) + ". " + datalist[i]["entry_name"],
                     )
 
-        elif datatype == "songs" or datatype == "fmsongs":
+        elif datatype == "songs" or datatype == "djprograms" or datatype == "fmsongs":
             iter_range = min(len(datalist), offset + step)
             for i in range(offset, iter_range):
                 if isinstance(datalist[i], str):

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -629,7 +629,7 @@ class Ui(object):
                         i - offset + 9, self.startcol, str(i) + ". " + datalist[i]
                     )
 
-        elif datatype == "djchannels":
+        elif datatype == "djRadios":
             for i in range(offset, min(len(datalist), offset + step)):
                 if i == index:
                     self.addstr(

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -160,11 +160,11 @@ class Ui(object):
 
         if artist or album_name:
             song_info = "{}{}{}  < {} >".format(
-                            song_name,
-                            self.space,
-                            artist,
-                            album_name,
-                        )
+                song_name,
+                self.space,
+                artist,
+                album_name,
+            )
         else:
             song_info = song_name
 

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -158,12 +158,16 @@ class Ui(object):
                 1, self.indented_startcol, "♫  ♪ ♫  ♪ " + quality, curses.color_pair(3)
             )
 
-        song_info = "{}{}{}  < {} >".format(
-                        song_name,
-                        self.space,
-                        artist,
-                        album_name,
-                    )
+        if artist or album_name:
+            song_info = "{}{}{}  < {} >".format(
+                            song_name,
+                            self.space,
+                            artist,
+                            album_name,
+                        )
+        else:
+            song_info = song_name
+
         if truelen(song_info) <= self.endcol - self.indented_startcol - 19:
             self.addstr(
                 1,

--- a/NEMbox/utils.py
+++ b/NEMbox/utils.py
@@ -80,7 +80,7 @@ def notify_command_linux(msg, duration_time=None):
 
 
 def notify(msg, msg_type=0, duration_time=None):
-    """ Show system notification with duration t (ms) """
+    """Show system notification with duration t (ms)"""
     msg = msg.replace('"', '\\"')
     if platform.system() == "Darwin":
         command = notify_command_osx(msg, msg_type, duration_time)


### PR DESCRIPTION
详细信息：
1. 添加 主播电台 搜索功能
2. 添加 函数 以获取全部电台节目
3. 修复 电台节目 api返回空歌名
4. 修复 网络波动、电台节目歌单过大（>=400），导致的空数据返回，并修复由于空数据返回在Parse.songs导致的KeyError
5. 修复 将主播电台的一二级页面（datatype == “djchannels”）分离为主播电台（djRadios）和电台节目（djprograms），以避免 space key event 在一级页面出错
6. 改变 播放歌曲时，若无艺术家、专辑名，只显示歌曲名

"dig_info"函数中为解决空值返回加的循环，获取2000首歌的歌单大概慢个2、3秒