### PR TITLE
fix(ui): 修复中文搜索退格后 UnicodeDecodeError

### DIFF
--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -21,6 +21,7 @@ from . import logger
 from .config import Config
 from .scrollstring import scrollstring, truelen, truelen_cut
 from .storage import Storage
+from .utils import decode_terminal_input
 
 log = logger.getLogger(__name__)
 
@@ -767,6 +768,47 @@ class Ui:
         self.screen.timeout(100)
         return x
 
+    def _read_line_input(self, y, x, max_len=60):
+        """Read a line with UTF-8 aware backspace (get_wch), fallback to getstr."""
+        if not hasattr(self.screen, "get_wch"):
+            raw = self.screen.getstr(y, x, max_len)
+            return decode_terminal_input(raw)
+
+        curses.curs_set(1)
+        chars = []
+        self.screen.move(y, x)
+
+        while True:
+            try:
+                ch = self.screen.get_wch()
+            except curses.error:
+                ch = self.screen.getch()
+
+            if isinstance(ch, str):
+                if len(chars) >= max_len:
+                    continue
+                chars.append(ch)
+                with contextlib.suppress(curses.error):
+                    self.addstr(ch)
+            elif ch in (curses.KEY_ENTER, 10, 13):
+                break
+            elif ch in (curses.KEY_BACKSPACE, 8, 127, 263):
+                if chars:
+                    chars.pop()
+                    line = "".join(chars)
+                    self.screen.move(y, x)
+                    self.screen.clrtoeol()
+                    if line:
+                        self.addstr(y, x, line)
+                    self.screen.move(y, x + truelen(line))
+            elif ch == 27:
+                chars.clear()
+                self.screen.move(y, x)
+                self.screen.clrtoeol()
+                break
+
+        return "".join(chars)
+
     def build_timing(self):
         curses.curs_set(0)
         self.screen.move(6, 1)
@@ -780,20 +822,22 @@ class Ui:
             curses.color_pair(1),
         )
         self.screen.timeout(-1)  # disable the screen timeout
-        curses.echo()
-        timing_time = self.screen.getstr(8, self.startcol + 19, 60)
+        curses.noecho()
+        timing_time = self._read_line_input(8, self.startcol + 19, 60)
         self.screen.timeout(100)  # restore the screen timeout
         return timing_time
 
     def get_param(self, prompt_string):
         # keep playing info in line 1
-        curses.echo()
+        curses.noecho()
         self.screen.move(4, 1)
         self.screen.clrtobot()
         self.addstr(5, self.startcol, prompt_string, curses.color_pair(1))
         self.screen.refresh()
-        keyword = self.screen.getstr(10, self.startcol, 60)
-        return keyword.decode("utf-8").strip()
+        try:
+            return self._read_line_input(10, self.startcol, 60).strip()
+        finally:
+            curses.curs_set(0)
 
     def update_size(self):
         curses.curs_set(0)

--- a/NEMbox/utils.py
+++ b/NEMbox/utils.py
@@ -18,6 +18,7 @@ __all__ = [
     "create_dir",
     "create_file",
     "md5",
+    "decode_terminal_input",
 ]
 
 
@@ -47,6 +48,13 @@ def create_file(path, default="\n"):
     if not os.path.exists(path):
         with open(path, "w") as f:
             f.write(default)
+
+
+def decode_terminal_input(raw: bytes) -> str:
+    """Decode curses getstr bytes, ignoring broken UTF-8 from byte-wise backspace."""
+    if not raw:
+        return ""
+    return raw.decode("utf-8", errors="ignore").strip()
 
 
 def uniq(arr):

--- a/tests/test_terminal_input.py
+++ b/tests/test_terminal_input.py
@@ -1,0 +1,19 @@
+from NEMbox.utils import decode_terminal_input
+
+
+def test_decode_terminal_input_empty():
+    assert decode_terminal_input(b"") == ""
+
+
+def test_decode_terminal_input_valid_utf8():
+    assert decode_terminal_input("你好".encode()) == "你好"
+
+
+def test_decode_terminal_input_ignores_broken_utf8_after_backspace():
+    # Simulates deleting the first byte of a 3-byte Chinese character.
+    broken = b"ab" + b"\xbd\xa0"
+    assert decode_terminal_input(broken) == "ab"
+
+
+def test_decode_terminal_input_strips_whitespace():
+    assert decode_terminal_input(b"  test  ") == "test"


### PR DESCRIPTION
## Summary
- 修复 #908：搜索中文歌曲时用 Backspace 删字后触发 `UnicodeDecodeError`
- `get_param` 改用 `get_wch` 按字符退格，避免截断 UTF-8 多字节序列
- 终端不支持 `get_wch` 时 fallback 到 `getstr`，并用 `decode_terminal_input` 忽略无效字节
- `build_timing` 同步使用相同输入逻辑

## Test plan
- [x] `poetry run pytest tests/test_terminal_input.py -q`
- [ ] 搜索中文歌曲，打错字后 Backspace 修正再搜索，不再崩溃

Fixes #908

Made with [Cursor](https://cursor.com)