### PR TITLE
fix(menu): 无播放时按 i 不再误打开歌曲页

### DIFF
--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -1036,7 +1036,7 @@ class Menu:
             # 在网页打开 ord(i)
             elif (
                 C.keyname(key).decode("utf-8") == KEY_MAP["musicInfo"]
-                and self.player.playing_id != -1
+                and self.player.playing_id is not None
             ):
                 webbrowser.open_new_tab(
                     f"http://music.163.com/song?id={self.player.playing_id}"

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,0 +1,9 @@
+from unittest.mock import PropertyMock, patch
+
+from NEMbox.player import Player
+
+
+def test_playing_id_is_none_without_current_song():
+    with patch.object(Player, "current_song", new_callable=PropertyMock, return_value={}):
+        player = Player.__new__(Player)
+        assert player.playing_id is None


### PR DESCRIPTION
## Summary
- 修复 #803 / #719：无播放时按 `i` 的行为异常
- `Player.playing_id` 在无当前歌曲时返回 `None`（#858 已用 `.get()` 消除 KeyError）
- 菜单侧原先用 `playing_id != -1` 判断，在 `None` 时仍为真，会打开 `song?id=None`
- 改为 `playing_id is not None`

## Test plan
- [x] `poetry run pytest tests/test_player.py -q`
- [ ] 未播放任何歌曲时按 `i`，程序不崩溃、不打开浏览器

Fixes #803, #719

Made with [Cursor](https://cursor.com)