### PR TITLE
feat: 支持无损和云盘播放

### DIFF
--- a/NEMbox/__init__.py
+++ b/NEMbox/__init__.py
@@ -47,7 +47,7 @@ def _parse_version(version: str) -> tuple[int, ...]:
 
 
 _versions = [_parse_version(d.version) for d in distributions(name="NetEase-MusicBox")]
-__version__ = ".".join(map(str, max(_versions))) if _versions else "0.5.0"
+__version__ = ".".join(map(str, max(_versions))) if _versions else "0.5.1"
 
 
 def create_config():

--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -156,8 +156,40 @@ DEFAULT_TIMEOUT = 10
 BASE_URL = "https://music.163.com"
 EAPI_BASE_URL = "https://interface.music.163.com"
 
-# music_quality -> song/url/v1 level (mp3 only, mpg123)
-QUALITY_LEVEL_MAP = {0: "exhigh", 1: "higher", 2: "standard"}
+# music_quality -> song/url/v1 level
+QUALITY_LEVEL_MAP = {
+    0: "exhigh",
+    1: "higher",
+    2: "standard",
+    3: "lossless",
+    4: "hires",
+}
+QUALITY_LEVELS = {
+    "standard",
+    "higher",
+    "exhigh",
+    "lossless",
+    "hires",
+    "jyeffect",
+    "sky",
+    "jymaster",
+}
+LOSSLESS_LEVELS = {"lossless", "hires", "jymaster"}
+
+
+def music_quality_to_level(quality):
+    if isinstance(quality, str):
+        normalized = quality.strip().lower()
+        if normalized.isdigit():
+            return QUALITY_LEVEL_MAP.get(int(normalized), "exhigh")
+        if normalized in QUALITY_LEVELS:
+            return normalized
+        return "exhigh"
+    return QUALITY_LEVEL_MAP.get(quality, "exhigh")
+
+
+def level_to_encode_type(level):
+    return "flac" if level in LOSSLESS_LEVELS else "mp3"
 
 EAPI_OS = {
     "os": "iphone",
@@ -182,7 +214,17 @@ class Parse:
             url = song["url"]
             if url is None:
                 return Parse._song_url_by_id(song["id"])
-            br = song["br"]
+            level = str(song.get("level") or "").upper()
+            song_type = str(song.get("type") or "").upper()
+            if level in {"LOSSLESS", "HIRES", "JYMASTER"} and song_type:
+                return url, f"{level} {song_type}"
+            if song_type == "FLAC" and level:
+                return url, f"{level} FLAC"
+            if song_type == "FLAC":
+                return url, "LOSSLESS FLAC"
+            br = song.get("br", 0) or 0
+            if br >= 999000:
+                return url, "LOSSLESS"
             if br >= 320000:
                 quality = "HD"
             elif br >= 192000:
@@ -256,12 +298,31 @@ class Parse:
                 "album_name": album_name,
                 "album_id": album_id,
                 "mp3_url": url,
+                "type": song.get("type", ""),
+                "level": song.get("level", ""),
+                "duration": int((song.get("dt") or song.get("duration") or 0) / 1000),
                 "quality": quality,
                 "expires": song["expires"],
                 "get_time": song["get_time"],
             }
             song_info_list.append(song_info)
         return song_info_list
+
+    @classmethod
+    def cloud_songs(cls, data):
+        songs = []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            song = (
+                item.get("simpleSong")
+                or item.get("song")
+                or item.get("simple_song")
+                or item
+            )
+            if isinstance(song, dict) and song.get("id"):
+                songs.append(song)
+        return songs
 
     @classmethod
     def artists(cls, artists):
@@ -576,17 +637,17 @@ class NetEase:
         path = "/weapi/w/nuser/account/get"
         return self.request("POST", path)
 
-    # 每日签到
-    def daily_task(self, is_mobile=True):
-        path = "/weapi/point/dailyTask"
-        params = {"type": 0 if is_mobile else 1}
-        return self.request("POST", path, params)
-
     # 用户歌单
     def user_playlist(self, uid, offset=0, limit=50):
         path = "/weapi/user/playlist"
         params = {"uid": uid, "offset": offset, "limit": limit}
         return self.request("POST", path, params).get("playlist", [])
+
+    # 我的云盘
+    def user_cloud(self, offset=0, limit=100):
+        path = "/weapi/v1/cloud/get"
+        params = {"offset": offset, "limit": limit}
+        return self.request("POST", path, params).get("data", [])
 
     # 每日推荐歌单
     def recommend_resource(self):
@@ -712,13 +773,13 @@ class NetEase:
 
     def songs_url(self, ids):
         quality = Config().get("music_quality")
-        level = QUALITY_LEVEL_MAP.get(quality, "exhigh")
+        level = music_quality_to_level(quality)
         if not isinstance(ids, list):
             ids = list(ids)
         params = {
             "ids": json.dumps(ids, separators=(",", ":")),
             "level": level,
-            "encodeType": "mp3",
+            "encodeType": level_to_encode_type(level),
         }
         result = self.eapi_request("/api/song/enhance/player/url/v1", params).get(
             "data", []
@@ -726,9 +787,16 @@ class NetEase:
         if result:
             return result
         # 降级：旧 weapi 按码率取链
-        rate_map = {0: 320000, 1: 192000, 2: 128000}
+        rate_map = {
+            "exhigh": 320000,
+            "higher": 192000,
+            "standard": 128000,
+            "lossless": 999000,
+            "hires": 999000,
+            "jymaster": 999000,
+        }
         path = "/weapi/song/enhance/player/url"
-        fallback_params = {"ids": ids, "br": rate_map.get(quality, 320000)}
+        fallback_params = {"ids": ids, "br": rate_map.get(level, 320000)}
         return self.request("POST", path, fallback_params).get("data", [])
 
     # lyric http://music.163.com/api/song/lyric?os=osx&id= &lv=-1&kv=-1&tv=-1
@@ -783,6 +851,9 @@ class NetEase:
     def dig_info(self, data, dig_type):
         if not data:
             return []
+        if dig_type == "cloud_songs":
+            return self.dig_info(Parse.cloud_songs(data), "songs")
+
         if dig_type == "songs" or dig_type == "fmsongs" or dig_type == "djprograms":
             sids = [x["id"] for x in data]
             # 可能因网络波动，返回空值，在Parse.songs中引发KeyError
@@ -798,6 +869,14 @@ class NetEase:
             else:
                 for i in range(0, len(sids), 500):
                     sds.extend(self.songs_detail(sids[i : i + 500]))
+                detail_ids = {s.get("id") for s in sds}
+                for song in data:
+                    if (
+                        isinstance(song, dict)
+                        and song.get("id") not in detail_ids
+                        and song.get("name")
+                    ):
+                        sds.append(song)
             # api 返回的 urls 的 id 顺序和 data 的 id 顺序不一致
             # 为了获取到对应 id 的 url，对返回的 urls 做一个 id2index 的缓存
             # 同时保证 data 的 id 顺序不变
@@ -812,8 +891,10 @@ class NetEase:
                     log.error("can't get song url, id: %s", s["id"])
                     return []
                 s["url"] = urls[url_index]["url"]
-                s["br"] = urls[url_index]["br"]
-                s["expires"] = urls[url_index]["expi"]
+                s["br"] = urls[url_index].get("br", 0)
+                s["type"] = urls[url_index].get("type", "")
+                s["level"] = urls[url_index].get("level", "")
+                s["expires"] = urls[url_index].get("expi", -1)
                 s["get_time"] = timestamp
             return Parse.songs(sds)
 
@@ -828,7 +909,9 @@ class NetEase:
                 song = {}
                 song["song_id"] = url_info["id"]
                 song["mp3_url"] = url_info["url"]
-                song["expires"] = url_info["expi"]
+                song["type"] = url_info.get("type", "")
+                song["level"] = url_info.get("level", "")
+                song["expires"] = url_info.get("expi", -1)
                 song["get_time"] = timestamp
                 songs.append(song)
             return songs

--- a/NEMbox/api.py
+++ b/NEMbox/api.py
@@ -191,6 +191,7 @@ def music_quality_to_level(quality):
 def level_to_encode_type(level):
     return "flac" if level in LOSSLESS_LEVELS else "mp3"
 
+
 EAPI_OS = {
     "os": "iphone",
     "appver": "9.0.90",

--- a/NEMbox/cache.py
+++ b/NEMbox/cache.py
@@ -152,7 +152,9 @@ class Cache(Singleton):
 
     def add(self, song_id, song_name, artist, url, onExit, song_type="", level=""):
         self.check_lock.acquire()
-        self.downloading.append([song_id, song_name, artist, url, onExit, song_type, level])
+        self.downloading.append(
+            [song_id, song_name, artist, url, onExit, song_type, level]
+        )
         self.check_lock.release()
 
     def quit(self):

--- a/NEMbox/cache.py
+++ b/NEMbox/cache.py
@@ -8,14 +8,36 @@ import os
 import signal
 import subprocess
 import threading
+from urllib.parse import urlparse
 
 from . import logger
-from .api import NetEase
+from .api import LOSSLESS_LEVELS, NetEase, music_quality_to_level
 from .config import Config
 from .const import Constant
 from .singleton import Singleton
 
 log = logger.getLogger(__name__)
+
+
+def infer_cache_extension(url="", song_type="", level="", configured_quality=None):
+    if str(song_type or "").lower() == "flac":
+        return ".flac"
+
+    parsed_path = urlparse(url or "").path.lower()
+    for ext in (".flac", ".mp3"):
+        if parsed_path.endswith(ext):
+            return ext
+
+    normalized_level = str(level or "").lower()
+    if normalized_level in LOSSLESS_LEVELS:
+        return ".flac"
+
+    if configured_quality is not None:
+        configured_level = music_quality_to_level(configured_quality)
+        if configured_level in LOSSLESS_LEVELS:
+            return ".flac"
+
+    return ".mp3"
 
 
 class Cache(Singleton):
@@ -69,11 +91,26 @@ class Cache(Singleton):
             artist = data[2]
             url = data[3]
             onExit = data[4]
+            song_type = data[5] if len(data) > 5 else ""
+            level = data[6] if len(data) > 6 else ""
             output_path = Constant.download_dir
-            output_file = str(artist) + " - " + str(song_name) + ".mp3"
+            ext = infer_cache_extension(
+                url, song_type, level, self.config.get("music_quality")
+            )
+            output_file = str(artist) + " - " + str(song_name) + ext
             full_path = os.path.join(output_path, output_file)
 
-            new_url = NetEase().songs_url([song_id])[0]["url"]
+            url_info = NetEase().songs_url([song_id])[0]
+            new_url = url_info["url"]
+            if not song_type:
+                song_type = url_info.get("type", "")
+            if not level:
+                level = url_info.get("level", "")
+            ext = infer_cache_extension(
+                new_url, song_type, level, self.config.get("music_quality")
+            )
+            output_file = str(artist) + " - " + str(song_name) + ext
+            full_path = os.path.join(output_path, output_file)
             if new_url:
                 log.info(f"Old:{url}. New:{new_url}")
                 try:
@@ -113,9 +150,9 @@ class Cache(Singleton):
                     onExit(song_id, full_path)
         self.download_lock.release()
 
-    def add(self, song_id, song_name, artist, url, onExit):
+    def add(self, song_id, song_name, artist, url, onExit, song_type="", level=""):
         self.check_lock.acquire()
-        self.downloading.append([song_id, song_name, artist, url, onExit])
+        self.downloading.append([song_id, song_name, artist, url, onExit, song_type, level])
         self.check_lock.release()
 
     def quit(self):

--- a/NEMbox/config.py
+++ b/NEMbox/config.py
@@ -15,7 +15,7 @@ class Config(Singleton):
 
         self.path = Constant.config_path
         self.default_config = {
-            "version": 8,
+            "version": 9,
             "page_length": {
                 "value": 10,
                 "default": 10,
@@ -34,6 +34,19 @@ class Config(Singleton):
                 "default": [],
                 "describe": "The additional parameters when mpg123 start.",
             },
+            "player_backend": {
+                "value": "mpg123",
+                "default": "mpg123",
+                "describe": (
+                    "Select player backend. "
+                    "mpg123 keeps legacy MP3 playback; mpv supports MP3/FLAC."
+                ),
+            },
+            "mpv_parameters": {
+                "value": [],
+                "default": [],
+                "describe": "The additional parameters when mpv start.",
+            },
             "aria2c_parameters": {
                 "value": [],
                 "default": [],
@@ -47,7 +60,8 @@ class Config(Singleton):
                 "describe": (
                     "Select the quality of the music. "
                     "May be useful when network is terrible. "
-                    "0 for high quality, 1 for medium and 2 for low."
+                    "0/exhigh for high, 1/higher for medium, 2/standard for low, "
+                    "3/lossless for FLAC lossless and 4/hires for hi-res."
                 ),
             },
             "global_play_pause": {

--- a/NEMbox/menu.py
+++ b/NEMbox/menu.py
@@ -148,6 +148,7 @@ class Menu:
             {"entry_name": "新碟上架"},
             {"entry_name": "精选歌单"},
             {"entry_name": "我的歌单"},
+            {"entry_name": "我的云盘"},
             {"entry_name": "主播电台"},
             {"entry_name": "每日推荐歌曲"},
             {"entry_name": "每日推荐歌单"},
@@ -339,16 +340,8 @@ class Menu:
             )
 
     def check_version(self):
-        # 检查更新 && 签到
+        # 检查更新
         try:
-            mobile = self.api.daily_task(is_mobile=True)
-            pc = self.api.daily_task(is_mobile=False)
-
-            if mobile["code"] == 200:
-                notify("移动端签到成功", 1)
-            if pc["code"] == 200:
-                notify("PC端签到成功", 1)
-
             data = self.api.get_version()
             return data["info"]["version"]
         except KeyError:
@@ -1026,7 +1019,14 @@ class Menu:
                     continue
                 cache_thread = threading.Thread(
                     target=self.player.cache_song,
-                    args=(s["song_id"], s["song_name"], s["artist"], s["mp3_url"]),
+                    args=(
+                        s["song_id"],
+                        s["song_name"],
+                        s["artist"],
+                        s["mp3_url"],
+                        s.get("type", ""),
+                        s.get("level", ""),
+                    ),
                 )
                 cache_thread.start()
             # 在网页打开 ord(i)
@@ -1303,36 +1303,41 @@ class Menu:
             self.datalist = self.api.dig_info(myplaylist, self.datatype)
             self.title += " > " + self.username + " 的歌单"
         elif idx == 5:
+            if not self.account and not self.login():
+                return
+            cloud_songs = self.request_api(self.api.user_cloud)
+            self.datatype = "songs"
+            self.title += " > " + self.username + " 的云盘"
+            self.datalist = self.api.dig_info(cloud_songs, "cloud_songs")
+        elif idx == 6:
             self.datatype = "djRadios"
             self.title += " > 主播电台"
             self.datalist = self.api.djRadios()
-        elif idx == 6:
-            if not self.account:
-                if not self.login():
-                    return
+        elif idx == 7:
+            if not self.account and not self.login():
+                return
             self.datatype = "songs"
             self.title += " > 每日推荐歌曲"
             myplaylist = self.request_api(self.api.recommend_playlist)
             if myplaylist is False:
                 return
             self.datalist = self.api.dig_info(myplaylist, self.datatype)
-        elif idx == 7:
-            if not self.account:
-                if not self.login():
-                    return
+        elif idx == 8:
+            if not self.account and not self.login():
+                return
             myplaylist = self.request_api(self.api.recommend_resource)
             self.datatype = "top_playlists"
             self.title += " > 每日推荐歌单"
             self.datalist = self.api.dig_info(myplaylist, self.datatype)
-        elif idx == 8:
+        elif idx == 9:
             self.datatype = "fmsongs"
             self.title += " > 私人FM"
             self.datalist = self.get_new_fm()
-        elif idx == 9:
+        elif idx == 10:
             self.datatype = "search"
             self.title += " > 搜索"
             self.datalist = ["歌曲", "艺术家", "专辑", "主播电台", "网易精选集"]
-        elif idx == 10:
+        elif idx == 11:
             self.datatype = "help"
             self.title += " > 帮助"
             self.datalist = shortcut

--- a/NEMbox/player.py
+++ b/NEMbox/player.py
@@ -426,13 +426,17 @@ class Player:
         self._cleanup_mpv_ipc()
         ipc_path = self._new_mpv_ipc_path()
         self.mpv_ipc_path = ipc_path
-        para = [
-            "mpv",
-            "--no-video",
-            "--really-quiet",
-            f"--input-ipc-server={ipc_path}",
-            f"--volume={self.info['playing_volume']}",
-        ] + self.config_mpv + [url]
+        para = (
+            [
+                "mpv",
+                "--no-video",
+                "--really-quiet",
+                f"--input-ipc-server={ipc_path}",
+                f"--volume={self.info['playing_volume']}",
+            ]
+            + self.config_mpv
+            + [url]
+        )
         try:
             process = subprocess.Popen(
                 para,
@@ -472,11 +476,7 @@ class Player:
         if process.returncode == 0:
             self.next()
             return
-        if (
-            expires >= 0
-            and get_time >= 0
-            and time.time() - expires - get_time >= 0
-        ):
+        if expires >= 0 and get_time >= 0 and time.time() - expires - get_time >= 0:
             self.refresh_urls()
             if self.refresh_url_flag:
                 self.stop()
@@ -640,7 +640,11 @@ class Player:
         that would give to subprocess.Popen.
         """
         # print(args.get('cache'))
-        url = args["cache"] if "cache" in args and os.path.isfile(args["cache"]) else args["mp3_url"]
+        url = (
+            args["cache"]
+            if "cache" in args and os.path.isfile(args["cache"])
+            else args["mp3_url"]
+        )
         backend = self._play_backend(args, url)
         runner = self.run_mpv if backend == "mpv" else self.run_mpg123
         self.playback_token += 1
@@ -649,7 +653,14 @@ class Player:
             if backend == "mpv":
                 thread = threading.Thread(
                     target=runner,
-                    args=(on_exit, args["cache"], -1, -1, args.get("duration", 0), token),
+                    args=(
+                        on_exit,
+                        args["cache"],
+                        -1,
+                        -1,
+                        args.get("duration", 0),
+                        token,
+                    ),
                 )
             else:
                 thread = threading.Thread(target=runner, args=(on_exit, args["cache"]))

--- a/NEMbox/player.py
+++ b/NEMbox/player.py
@@ -10,9 +10,12 @@
 from __future__ import annotations
 
 # Let's make some noise
+import json
 import os
 import random
+import socket
 import subprocess
+import tempfile
 import threading
 import time
 from collections.abc import Callable
@@ -43,6 +46,9 @@ class Player:
         self.config = Config()
         self.ui = Ui()
         self.popen_handler: Any = None
+        self.current_backend = ""
+        self.mpv_ipc_path = ""
+        self.playback_token = 0
         # flag stop, prevent thread start
         self.playing_flag = False
         self.refresh_url_flag = False
@@ -108,6 +114,10 @@ class Player:
         return self.config.get("mpg123_parameters")
 
     @property
+    def config_mpv(self):
+        return self.config.get("mpv_parameters")
+
+    @property
     def current_song(self) -> dict[str, Any]:
         if not self.songs:
             return {}
@@ -158,11 +168,15 @@ class Player:
         if not self.current_song:
             return
 
+        quality = self.current_song["quality"]
+        audio_quality = self.current_song.get("audio_quality", "")
+        if audio_quality and int(time.time() - self.playinfo_starts) % 6 >= 3:
+            quality = audio_quality
         self.ui.build_playinfo(
             self.current_song["song_name"],
             self.current_song["artist"],
             self.current_song["album_name"],
-            self.current_song["quality"],
+            quality,
             self.playinfo_starts,
             pause=not self.playing_flag,
         )
@@ -183,6 +197,8 @@ class Player:
                 song_id = str(song["song_id"])
                 if song_id in self.songs:
                     self.songs[song_id]["mp3_url"] = song["mp3_url"]
+                    self.songs[song_id]["type"] = song.get("type", "")
+                    self.songs[song_id]["level"] = song.get("level", "")
                     self.songs[song_id]["expires"] = song["expires"]
                     self.songs[song_id]["get_time"] = song["get_time"]
                 else:
@@ -190,16 +206,31 @@ class Player:
             self.refresh_url_flag = True
 
     def stop(self):
-        if not hasattr(self.popen_handler, "poll") or self.popen_handler.poll():
+        if (
+            not hasattr(self.popen_handler, "poll")
+            or self.popen_handler.poll() is not None
+        ):
             return
 
+        self.playback_token += 1
         self.playing_flag = False
         try:
-            if not self.popen_handler.poll() and not self.popen_handler.stdin.closed:
+            if (
+                self.current_backend == "mpg123"
+                and self.popen_handler.poll() is None
+                and self.popen_handler.stdin
+                and not self.popen_handler.stdin.closed
+            ):
                 self.popen_handler.stdin.write(b"Q\n")
                 self.popen_handler.stdin.flush()
                 self.popen_handler.communicate()
                 self.popen_handler.kill()
+            elif self.popen_handler.poll() is None:
+                self.popen_handler.terminate()
+                try:
+                    self.popen_handler.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    self.popen_handler.kill()
         except Exception as e:
             log.warn(e)
         finally:
@@ -213,7 +244,7 @@ class Player:
 
     def tune_volume(self, up=0):
         try:
-            if self.popen_handler.poll():
+            if self.popen_handler.poll() is not None:
                 return
         except Exception as e:
             log.warn("Unable to tune volume: " + str(e))
@@ -226,6 +257,8 @@ class Player:
             new_volume = 0
 
         self.info["playing_volume"] = new_volume
+        if self.current_backend == "mpv":
+            return
         try:
             self.popen_handler.stdin.write(
                 "V {}\n".format(self.info["playing_volume"]).encode()
@@ -237,7 +270,13 @@ class Player:
     def switch(self):
         if not self.popen_handler:
             return
-        if self.popen_handler.poll():
+        if self.popen_handler.poll() is not None:
+            return
+        if self.current_backend == "mpv":
+            self.playing_flag = not self.playing_flag
+            self._send_mpv_command(["set_property", "pause", not self.playing_flag])
+            self.playinfo_starts = time.time()
+            self.build_playinfo()
             return
         self.playing_flag = not self.playing_flag
         if not self.popen_handler.stdin.closed:
@@ -247,7 +286,212 @@ class Player:
         self.playinfo_starts = time.time()
         self.build_playinfo()
 
+    @staticmethod
+    def _is_flac_url(url):
+        if not url:
+            return False
+        url_part = url.split("?", 1)[0].lower()
+        return url_part.endswith(".flac") or ".flac/" in url_part
+
+    @classmethod
+    def _is_flac_song(cls, song, url):
+        song_type = str(song.get("type") or "").lower()
+        level = str(song.get("level") or "").lower()
+        return bool(
+            song_type == "flac"
+            or level in {"lossless", "hires", "jymaster"}
+            or cls._is_flac_url(url)
+        )
+
+    def _play_backend(self, song, url):
+        backend = str(self.config.get("player_backend") or "mpg123").lower()
+        if backend == "mpv" or self._is_flac_song(song, url):
+            return "mpv"
+        return "mpg123"
+
+    def _new_mpv_ipc_path(self):
+        return os.path.join(
+            tempfile.gettempdir(), f"musicbox-mpv-{os.getpid()}-{id(self)}.sock"
+        )
+
+    def _cleanup_mpv_ipc(self, path=None):
+        path = path if path is not None else getattr(self, "mpv_ipc_path", "")
+        if not path:
+            return
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            log.warn(e)
+        if path == getattr(self, "mpv_ipc_path", ""):
+            self.mpv_ipc_path = ""
+
+    def _is_current_playback(self, token, process=None):
+        if token != self.playback_token:
+            return False
+        return not (process is not None and self.popen_handler is not process)
+
+    def _send_mpv_command(self, command):
+        path = getattr(self, "mpv_ipc_path", "")
+        if not path:
+            return False
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.connect(path)
+                payload = json.dumps({"command": command}).encode() + b"\n"
+                client.sendall(payload)
+            return True
+        except OSError as e:
+            log.warn(e)
+            return False
+
+    def _request_mpv_property(self, name, path=None):
+        path = path or getattr(self, "mpv_ipc_path", "")
+        if not path:
+            return None
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.settimeout(0.2)
+                client.connect(path)
+                payload = json.dumps({"command": ["get_property", name]}).encode()
+                client.sendall(payload + b"\n")
+                data = b""
+                while b"\n" not in data:
+                    chunk = client.recv(4096)
+                    if not chunk:
+                        break
+                    data += chunk
+            if not data:
+                return None
+            response = json.loads(data.split(b"\n", 1)[0].decode())
+            if response.get("error") == "success":
+                return response.get("data")
+        except (OSError, ValueError):
+            pass
+        return None
+
+    @staticmethod
+    def _format_sample_rate(rate):
+        if not rate:
+            return ""
+        khz = float(rate) / 1000
+        text = f"{khz:.1f}".rstrip("0").rstrip(".")
+        return f"{text}kHz"
+
+    @staticmethod
+    def _format_sample_bits(fmt):
+        fmt = str(fmt or "").lower()
+        if fmt == "float":
+            return "32bit"
+        if fmt == "double":
+            return "64bit"
+        digits = "".join(ch for ch in fmt if ch.isdigit())
+        return f"{digits}bit" if digits else ""
+
+    @classmethod
+    def _format_audio_params(cls, params):
+        if not isinstance(params, dict):
+            return ""
+        parts = [
+            cls._format_sample_rate(params.get("samplerate")),
+            cls._format_sample_bits(params.get("format")),
+        ]
+        return " ".join(part for part in parts if part)
+
+    def _refresh_mpv_audio_info(self, ipc_path, token, process):
+        if not self._is_current_playback(token, process):
+            return False
+        label = self._format_audio_params(
+            self._request_mpv_property("audio-params", ipc_path)
+        )
+        if not label:
+            return False
+        song = self.current_song
+        if not song:
+            return False
+        song["audio_quality"] = label
+        return True
+
+    def run_mpv(self, on_exit, url, expires=-1, get_time=-1, duration=0, token=0):
+        self.current_backend = "mpv"
+        if not url:
+            self.notify_copyright_issue()
+            if not self.is_single_loop_mode:
+                self.next()
+            else:
+                self.stop()
+            return
+
+        self._cleanup_mpv_ipc()
+        ipc_path = self._new_mpv_ipc_path()
+        self.mpv_ipc_path = ipc_path
+        para = [
+            "mpv",
+            "--no-video",
+            "--really-quiet",
+            f"--input-ipc-server={ipc_path}",
+            f"--volume={self.info['playing_volume']}",
+        ] + self.config_mpv + [url]
+        try:
+            process = subprocess.Popen(
+                para,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self.popen_handler = process
+            self.process_length = max(int(duration or 0), 1)
+            self.process_location = 0
+            last_tick = time.time()
+            audio_info_loaded = False
+            while process.poll() is None:
+                now = time.time()
+                is_current = self._is_current_playback(token, process)
+                if self.playing_flag and is_current:
+                    self.process_location = min(
+                        self.process_location + now - last_tick,
+                        self.process_length,
+                    )
+                    if not audio_info_loaded:
+                        audio_info_loaded = self._refresh_mpv_audio_info(
+                            ipc_path, token, process
+                        )
+                last_tick = now
+                time.sleep(0.2)
+        except OSError as e:
+            log.error(e)
+            notify("mpv 不可用，无法播放无损音频")
+            self.playing_flag = False
+            self._cleanup_mpv_ipc(ipc_path)
+            return
+        self._cleanup_mpv_ipc(ipc_path)
+
+        if not self.playing_flag or not self._is_current_playback(token, process):
+            return
+        if process.returncode == 0:
+            self.next()
+            return
+        if (
+            expires >= 0
+            and get_time >= 0
+            and time.time() - expires - get_time >= 0
+        ):
+            self.refresh_urls()
+            if self.refresh_url_flag:
+                self.stop()
+                self.playing_flag = True
+                self.start_playing(lambda: 0, self.current_song)
+                self.refresh_url_flag = False
+            return
+        self.notify_copyright_issue()
+        if self.is_single_loop_mode:
+            self.stop()
+        else:
+            self.next()
+
     def run_mpg123(self, on_exit, url, expires=-1, get_time=-1):
+        self.current_backend = "mpg123"
         para = ["mpg123", "-R"] + self.config_mpg123
         self.popen_handler = subprocess.Popen(
             para, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -381,11 +625,11 @@ class Player:
 
         self.songs[str(self.playing_id)][key] = lyric
 
-    def download_song(self, song_id, song_name, artist, url):
+    def download_song(self, song_id, song_name, artist, url, song_type="", level=""):
         def write_path(song_id, path):
             self.songs[str(song_id)]["cache"] = path
 
-        self.cache.add(song_id, song_name, artist, url, write_path)
+        self.cache.add(song_id, song_name, artist, url, write_path, song_type, level)
         self.cache.start_download()
 
     def start_playing(self, on_exit, args):
@@ -396,14 +640,26 @@ class Player:
         that would give to subprocess.Popen.
         """
         # print(args.get('cache'))
+        url = args["cache"] if "cache" in args and os.path.isfile(args["cache"]) else args["mp3_url"]
+        backend = self._play_backend(args, url)
+        runner = self.run_mpv if backend == "mpv" else self.run_mpg123
+        self.playback_token += 1
+        token = self.playback_token
         if "cache" in args and os.path.isfile(args["cache"]):
-            thread = threading.Thread(
-                target=self.run_mpg123, args=(on_exit, args["cache"])
-            )
+            if backend == "mpv":
+                thread = threading.Thread(
+                    target=runner,
+                    args=(on_exit, args["cache"], -1, -1, args.get("duration", 0), token),
+                )
+            else:
+                thread = threading.Thread(target=runner, args=(on_exit, args["cache"]))
         else:
+            player_args = (on_exit, args["mp3_url"], args["expires"], args["get_time"])
+            if backend == "mpv":
+                player_args = (*player_args, args.get("duration", 0), token)
             thread = threading.Thread(
-                target=self.run_mpg123,
-                args=(on_exit, args["mp3_url"], args["expires"], args["get_time"]),
+                target=runner,
+                args=player_args,
             )
             cache_thread = threading.Thread(
                 target=self.download_song,
@@ -412,6 +668,8 @@ class Player:
                     args["song_name"],
                     args["artist"],
                     args["mp3_url"],
+                    args.get("type", ""),
+                    args.get("level", ""),
                 ),
             )
             cache_thread.start()
@@ -591,11 +849,11 @@ class Player:
         self.ui.update_size()
         self.build_playinfo()
 
-    def cache_song(self, song_id, song_name, artist, song_url):
+    def cache_song(self, song_id, song_name, artist, song_url, song_type="", level=""):
         def on_exit(song_id, path):
             self.songs[str(song_id)]["cache"] = path
             self.cache.enable = False
 
         self.cache.enable = True
-        self.cache.add(song_id, song_name, artist, song_url, on_exit)
+        self.cache.add(song_id, song_name, artist, song_url, on_exit, song_type, level)
         self.cache.start_download()

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -172,9 +172,7 @@ class Ui:
         self.screen.move(2, 1)
         self.screen.clrtoeol()
         prefix = "_ _ z Z Z " if pause else "♫  ♪ ♫  ♪ "
-        self.addstr(
-            1, self.indented_startcol, prefix + quality, curses.color_pair(3)
-        )
+        self.addstr(1, self.indented_startcol, prefix + quality, curses.color_pair(3))
 
         if artist or album_name:
             song_info = f"{song_name}{self.space}{artist}  < {album_name} >"

--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -45,6 +45,11 @@ def _is_escape_key(ch) -> bool:
         return ch == "\x1b"
     return ch == 27
 
+
+def playinfo_song_start(indented_startcol, prefix, quality):
+    return indented_startcol + truelen(prefix + quality) + 2
+
+
 try:
     dbus: Any | None = importlib.import_module("dbus")
 except ImportError:
@@ -166,24 +171,24 @@ class Ui:
         self.screen.clrtoeol()
         self.screen.move(2, 1)
         self.screen.clrtoeol()
-        if pause:
-            self.addstr(
-                1, self.indented_startcol, "_ _ z Z Z " + quality, curses.color_pair(3)
-            )
-        else:
-            self.addstr(
-                1, self.indented_startcol, "♫  ♪ ♫  ♪ " + quality, curses.color_pair(3)
-            )
+        prefix = "_ _ z Z Z " if pause else "♫  ♪ ♫  ♪ "
+        self.addstr(
+            1, self.indented_startcol, prefix + quality, curses.color_pair(3)
+        )
 
         if artist or album_name:
             song_info = f"{song_name}{self.space}{artist}  < {album_name} >"
         else:
             song_info = song_name
 
-        if truelen(song_info) <= self.endcol - self.indented_startcol - 19:
+        song_start = min(
+            playinfo_song_start(self.indented_startcol, prefix, quality),
+            self.indented_endcol - 1,
+        )
+        if truelen(song_info) <= self.endcol - song_start:
             self.addstr(
                 1,
-                min(self.indented_startcol + 18, self.indented_endcol - 1),
+                song_start,
                 song_info,
                 curses.color_pair(4),
             )
@@ -191,8 +196,8 @@ class Ui:
             song_info = scrollstring(song_info + " ", start)
             self.addstr(
                 1,
-                min(self.indented_startcol + 18, self.indented_endcol - 1),
-                truelen_cut(str(song_info), self.endcol - self.indented_startcol - 19),
+                song_start,
+                truelen_cut(str(song_info), self.endcol - song_start),
                 curses.color_pair(4),
             )
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,17 @@ musicbox
 
 无损播放相关配置：
 
-- `music_quality`: `0/exhigh`、`1/higher`、`2/standard`、`3/lossless`、`4/hires`，也可直接填写 `lossless`、`hires`、`jymaster`。
+- `music_quality`：音质等级，可填数字或 level 名称。
+
+  | 配置值 | 说明 |
+  | --- | --- |
+  | `jymaster` | 超清母带，192kHz/24bit |
+  | `4` / `hires` | 高清臻音，96kHz/24bit |
+  | `3` / `lossless` | 无损，最高 48kHz/16bit |
+  | `0` / `exhigh` | 极高，最高 320kbps |
+  | `1` / `higher` | 较高，192kbps |
+  | `2` / `standard` | 标准，128kbps |
+  
 - `player_backend`: 默认 `mpg123`。设置为 `mpv` 后所有歌曲都用 `mpv` 播放；保持默认时，FLAC 链接会自动切到 `mpv`。
 - `mpv_parameters`: 传给 `mpv` 的额外参数列表。
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # NetEase-MusicBox
 
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
-[![versions](https://img.shields.io/pypi/v/NetEase-MusicBox.svg)](https://pypi.org/project/NetEase-MusicBox/)
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/NetEase-MusicBox.svg)](https://pypi.org/project/NetEase-MusicBox/)
+![PyPI - Version](https://img.shields.io/pypi/v/NetEase-MusicBox)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/NetEase-MusicBox)
+
 
 高品质网易云音乐命令行客户端，基于 Python 编写。
 
@@ -16,7 +17,7 @@
 
 ## 功能特性
 
-- 支持 320kbps 高品质音乐播放
+- 支持 320kbps 高品质音乐播放，安装 `mpv` 后支持 FLAC 无损播放
 - 支持歌曲、艺术家、专辑、本地列表模糊搜索
 - 支持排行榜、新碟推荐、精选歌单、主播电台、私人歌单和每日推荐
 - 支持本地收藏、歌曲评论、专辑跳转、随心打碟和定时退出
@@ -30,7 +31,8 @@
 ### 环境要求
 
 - Python 3.10 及以上
-- `mpg123`，用于播放歌曲
+- `mpg123`，用于默认 MP3 播放
+- `mpv`，可选，用于 FLAC 无损/Hi-Res 播放
 
 `rapidfuzz` 和 `qrcode` 会随 MusicBox 自动安装，分别用于模糊搜索和扫码登录二维码生成。
 
@@ -39,19 +41,19 @@
 macOS:
 
 ```bash
-brew install mpg123 uv
+brew install mpg123 mpv uv
 ```
 
 Ubuntu/Debian:
 
 ```bash
-sudo apt-get install mpg123
+sudo apt-get install mpg123 mpv
 ```
 
 CentOS/Red Hat:
 
 ```bash
-sudo yum install -y python3-devel mpg123
+sudo yum install -y python3-devel mpg123 mpv
 ```
 
 ### 安装 MusicBox
@@ -65,6 +67,8 @@ uv tool install .
 ```
 
 也可以使用 `pipx install .`。如果希望源码改动实时生效，使用 `uv tool install -e .`。
+
+> `uv tool install .` / `pipx install .` 安装的是源码的一份快照副本，之后修改源码不会自动生效，需重新执行安装命令。如需源码改动实时生效，用 `uv tool install -e .`。
 
 从 PyPI 安装：
 
@@ -156,7 +160,13 @@ musicbox
 
 ## 配置
 
-配置文件位于 `~/.config/netease-musicbox/config.json`，可配置缓存、快捷键、消息提示和桌面歌词。
+配置文件位于 `~/.netease-musicbox/config.json`，可配置缓存、快捷键、消息提示和桌面歌词。
+
+无损播放相关配置：
+
+- `music_quality`: `0/exhigh`、`1/higher`、`2/standard`、`3/lossless`、`4/hires`，也可直接填写 `lossless`、`hires`、`jymaster`。
+- `player_backend`: 默认 `mpg123`。设置为 `mpv` 后所有歌曲都用 `mpv` 播放；保持默认时，FLAC 链接会自动切到 `mpv`。
+- `mpv_parameters`: 传给 `mpv` 的额外参数列表。
 
 由于歌曲 API 只接受中国大陆地区访问，非中国大陆地区用户需要自行设置代理。可用 polipo 将 socks5 代理转换成 http 代理：
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "NetEase-MusicBox"
 packages = [
   {include = "NEMbox"},
 ]
-version = "0.5.0"
+version = "0.5.1"
 # docs
 authors = [
   "omi <4399.omi@gmail.com>",

--- a/tests/test_audio_quality.py
+++ b/tests/test_audio_quality.py
@@ -1,0 +1,38 @@
+from NEMbox.api import Parse
+
+
+def test_parse_song_url_hides_lossless_bitrate():
+    url, quality = Parse.song_url(
+        {
+            "id": 1,
+            "url": "https://example.test/song",
+            "br": 2163000,
+        }
+    )
+
+    assert url == "https://example.test/song"
+    assert quality == "LOSSLESS"
+
+
+def test_parse_song_url_keeps_mp3_bitrate():
+    assert Parse.song_url({"id": 1, "url": "u", "br": 320000}) == ("u", "HD 320k")
+
+
+def test_parse_songs_keeps_duration_for_mpv_progress():
+    songs = Parse.songs(
+        [
+            {
+                "id": 1,
+                "name": "song",
+                "ar": [{"name": "artist"}],
+                "al": {"name": "album", "id": 2},
+                "url": "https://example.test/song.flac",
+                "br": 2163000,
+                "dt": 243000,
+                "expires": -1,
+                "get_time": 1,
+            }
+        ]
+    )
+
+    assert songs[0]["duration"] == 243

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -7,3 +7,101 @@ def test_playing_id_is_none_without_current_song():
     with patch.object(Player, "current_song", new_callable=PropertyMock, return_value={}):
         player = Player.__new__(Player)
         assert player.playing_id is None
+
+
+class FakePopen:
+    def poll(self):
+        return None
+
+
+def test_mpv_switch_uses_ipc_pause_command():
+    player = Player.__new__(Player)
+    player.popen_handler = FakePopen()
+    player.current_backend = "mpv"
+    player.playing_flag = True
+    player.build_playinfo = lambda: None
+    commands = []
+    player._send_mpv_command = commands.append
+
+    player.switch()
+    player.switch()
+
+    assert commands == [
+        ["set_property", "pause", True],
+        ["set_property", "pause", False],
+    ]
+
+
+def test_stale_playback_token_is_not_current():
+    player = Player.__new__(Player)
+    process = FakePopen()
+    player.popen_handler = process
+    player.playback_token = 2
+
+    assert player._is_current_playback(2, process)
+    assert not player._is_current_playback(1, process)
+    assert not player._is_current_playback(2, FakePopen())
+
+
+def test_format_audio_params():
+    assert (
+        Player._format_audio_params({"samplerate": 44100, "format": "s16"})
+        == "44.1kHz 16bit"
+    )
+    assert (
+        Player._format_audio_params({"samplerate": 96000, "format": "s24"})
+        == "96kHz 24bit"
+    )
+    assert (
+        Player._format_audio_params({"samplerate": 48000, "format": "float"})
+        == "48kHz 32bit"
+    )
+
+
+def test_refresh_mpv_audio_info_stores_audio_quality_separately():
+    player = Player.__new__(Player)
+    process = FakePopen()
+    song = {"quality": "LOSSLESS"}
+    player.popen_handler = process
+    player.playback_token = 1
+    player._request_mpv_property = lambda name, path: {
+        "samplerate": 44100,
+        "format": "s16",
+    }
+
+    with patch.object(Player, "current_song", new_callable=PropertyMock) as current_song:
+        current_song.return_value = song
+        assert player._refresh_mpv_audio_info("sock", 1, process)
+        assert player._refresh_mpv_audio_info("sock", 1, process)
+
+    assert song["quality"] == "LOSSLESS"
+    assert song["audio_quality"] == "44.1kHz 16bit"
+
+
+def test_build_playinfo_rotates_quality_label(monkeypatch):
+    player = Player.__new__(Player)
+    player.playinfo_starts = 100
+    player.playing_flag = True
+    song = {
+        "song_name": "song",
+        "artist": "artist",
+        "album_name": "album",
+        "quality": "LOSSLESS",
+        "audio_quality": "44.1kHz 16bit",
+    }
+    calls = []
+    player.ui = type(
+        "FakeUi",
+        (),
+        {"build_playinfo": lambda self, *args, **kwargs: calls.append((args, kwargs))},
+    )()
+
+    with patch.object(Player, "current_song", new_callable=PropertyMock) as current_song:
+        current_song.return_value = song
+        monkeypatch.setattr("NEMbox.player.time.time", lambda: 101)
+        player.build_playinfo()
+        monkeypatch.setattr("NEMbox.player.time.time", lambda: 104)
+        player.build_playinfo()
+
+    assert calls[0][0][3] == "LOSSLESS"
+    assert calls[1][0][3] == "44.1kHz 16bit"

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -4,7 +4,9 @@ from NEMbox.player import Player
 
 
 def test_playing_id_is_none_without_current_song():
-    with patch.object(Player, "current_song", new_callable=PropertyMock, return_value={}):
+    with patch.object(
+        Player, "current_song", new_callable=PropertyMock, return_value={}
+    ):
         player = Player.__new__(Player)
         assert player.playing_id is None
 
@@ -69,7 +71,9 @@ def test_refresh_mpv_audio_info_stores_audio_quality_separately():
         "format": "s16",
     }
 
-    with patch.object(Player, "current_song", new_callable=PropertyMock) as current_song:
+    with patch.object(
+        Player, "current_song", new_callable=PropertyMock
+    ) as current_song:
         current_song.return_value = song
         assert player._refresh_mpv_audio_info("sock", 1, process)
         assert player._refresh_mpv_audio_info("sock", 1, process)
@@ -96,7 +100,9 @@ def test_build_playinfo_rotates_quality_label(monkeypatch):
         {"build_playinfo": lambda self, *args, **kwargs: calls.append((args, kwargs))},
     )()
 
-    with patch.object(Player, "current_song", new_callable=PropertyMock) as current_song:
+    with patch.object(
+        Player, "current_song", new_callable=PropertyMock
+    ) as current_song:
         current_song.return_value = song
         monkeypatch.setattr("NEMbox.player.time.time", lambda: 101)
         player.build_playinfo()

--- a/tests/test_ui_playinfo.py
+++ b/tests/test_ui_playinfo.py
@@ -1,0 +1,12 @@
+from NEMbox.scrollstring import truelen
+from NEMbox.ui import playinfo_song_start
+
+
+def test_playinfo_song_start_accounts_for_long_quality_label():
+    prefix = "♫  ♪ ♫  ♪ "
+    quality = "LOSSLESS"
+
+    start = playinfo_song_start(0, prefix, quality)
+
+    assert start == truelen(prefix + quality) + 2
+    assert start > 18


### PR DESCRIPTION
## 变更

- 扩展 music_quality，支持 lossless/hires/jymaster 取链
- 新增 mpv 播放后端，支持 FLAC 播放、暂停、进度和音频参数轮换展示
- 新增我的云盘入口，支持云盘歌曲播放
- 调整缓存扩展名推断，支持 .flac
- 更新 README 和版本号到 0.5.1

## 验证

- poetry run ruff check NEMbox tests
- XDG_CONFIG_HOME=/private/tmp/musicbox-test-config XDG_DATA_HOME=/private/tmp/musicbox-test-data XDG_CACHE_HOME=/private/tmp/musicbox-test-cache poetry run pytest